### PR TITLE
Gh 0027

### DIFF
--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -114,6 +114,8 @@ public class OozieClient {
     public static final String CHANGE_VALUE_PAUSETIME = "pausetime";
 
     public static final String CHANGE_VALUE_CONCURRENCY = "concurrency";
+    
+    public static final String LIBPATH = "oozie.libpath";
 
     public static enum SYSTEM_MODE {
         NORMAL, NOWEBSERVICE, SAFEMODE

--- a/client/src/main/java/org/apache/oozie/client/XOozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/XOozieClient.java
@@ -37,8 +37,6 @@ public class XOozieClient extends OozieClient {
 
     public static final String NN_PRINCIPAL = "dfs.namenode.kerberos.principal";
 
-    public static final String LIBPATH = "oozie.libpath";
-
     public static final String PIG_SCRIPT = "oozie.pig.script";
 
     public static final String PIG_OPTIONS = "oozie.pig.options";
@@ -104,13 +102,13 @@ public class XOozieClient extends OozieClient {
             throw new RuntimeException("namenode is not specified in conf");
         }
 
-        String libPath = conf.getProperty(XOozieClient.LIBPATH);
+        String libPath = conf.getProperty(LIBPATH);
         if (libPath == null) {
             throw new RuntimeException("libpath is not specified in conf");
         }
         if (!libPath.startsWith("hdfs://")) {
             String newLibPath = NN + libPath;
-            conf.setProperty(XOozieClient.LIBPATH, newLibPath);
+            conf.setProperty(LIBPATH, newLibPath);
         }
     }
 
@@ -186,7 +184,7 @@ public class XOozieClient extends OozieClient {
      * @param path lib HDFS path.
      */
     public void setLib(Properties conf, String pathStr) {
-        conf.setProperty(XOozieClient.LIBPATH, pathStr);
+        conf.setProperty(LIBPATH, pathStr);
     }
 
     /**

--- a/core/src/main/java/org/apache/oozie/command/wf/ReRunCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/ReRunCommand.java
@@ -146,7 +146,7 @@ public class ReRunCommand extends WorkflowCommand<Void> {
         try {
             XLog.Info.get().setParameter(DagXLogInfoService.TOKEN, conf.get(OozieClient.LOG_TOKEN));
             WorkflowApp app = wps.parseDef(conf, authToken);
-            XConfiguration protoActionConf = wps.createProtoActionConf(conf, authToken);
+            XConfiguration protoActionConf = wps.createProtoActionConf(conf, authToken, true);
             WorkflowLib workflowLib = Services.get().get(WorkflowStoreService.class).getWorkflowLibWithNoDB();
 
             Path configDefault = new Path(conf.get(OozieClient.APP_PATH), SubmitCommand.CONFIG_DEFAULT);

--- a/core/src/main/java/org/apache/oozie/command/wf/SubmitCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/SubmitCommand.java
@@ -105,7 +105,7 @@ public class SubmitCommand extends WorkflowCommand<String> {
         try {
             XLog.Info.get().setParameter(DagXLogInfoService.TOKEN, conf.get(OozieClient.LOG_TOKEN));
             WorkflowApp app = wps.parseDef(conf, authToken);
-            XConfiguration protoActionConf = wps.createProtoActionConf(conf, authToken);
+            XConfiguration protoActionConf = wps.createProtoActionConf(conf, authToken, true);
             WorkflowLib workflowLib = Services.get().get(WorkflowStoreService.class).getWorkflowLibWithNoDB();
 
             Path configDefault = new Path(conf.get(OozieClient.APP_PATH), CONFIG_DEFAULT);

--- a/core/src/main/java/org/apache/oozie/command/wf/SubmitHttpCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/SubmitHttpCommand.java
@@ -51,7 +51,7 @@ public abstract class SubmitHttpCommand extends WorkflowCommand<String> {
     static {
         MANDATORY_OOZIE_CONFS.add(XOozieClient.JT);
         MANDATORY_OOZIE_CONFS.add(XOozieClient.NN);
-        MANDATORY_OOZIE_CONFS.add(XOozieClient.LIBPATH);
+        MANDATORY_OOZIE_CONFS.add(OozieClient.LIBPATH);
 
         OPTIONAL_OOZIE_CONFS.add(XOozieClient.FILES);
         OPTIONAL_OOZIE_CONFS.add(XOozieClient.ARCHIVES);
@@ -100,7 +100,7 @@ public abstract class SubmitHttpCommand extends WorkflowCommand<String> {
             XLog.getLog(getClass()).debug("workflow xml created on the server side is :\n");
             XLog.getLog(getClass()).debug(wfXml);
             WorkflowApp app = wps.parseDef(wfXml);
-            XConfiguration protoActionConf = wps.createProtoActionConf(conf, authToken);
+            XConfiguration protoActionConf = wps.createProtoActionConf(conf, authToken, false);
             WorkflowLib workflowLib = Services.get().get(WorkflowStoreService.class).getWorkflowLibWithNoDB();
 
             PropertiesUtils.checkDisallowedProperties(conf, DISALLOWED_USER_PROPERTIES);

--- a/core/src/main/java/org/apache/oozie/service/AuthorizationService.java
+++ b/core/src/main/java/org/apache/oozie/service/AuthorizationService.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.oozie.CoordinatorJobBean;
 import org.apache.oozie.ErrorCode;
 import org.apache.oozie.WorkflowJobBean;
-import org.apache.oozie.client.XOozieClient;
+import org.apache.oozie.client.OozieClient;
 import org.apache.oozie.store.CoordinatorStore;
 import org.apache.oozie.store.StoreException;
 import org.apache.oozie.store.WorkflowStore;
@@ -288,7 +288,7 @@ public class AuthorizationService implements Service {
                     incrCounter(INSTR_FAILED_AUTH_COUNTER, 1);
                     throw new AuthorizationException(ErrorCode.E0504, appPath);
                 }
-                if (conf.get(XOozieClient.LIBPATH) == null) { // Only check existance of wfXml for non http submission jobs;
+                if (conf.get(OozieClient.LIBPATH) == null) { // Only check existance of wfXml for non http submission jobs;
                     Path wfXml = new Path(path, fileName);
                     if (!fs.exists(wfXml)) {
                         incrCounter(INSTR_FAILED_AUTH_COUNTER, 1);

--- a/core/src/main/java/org/apache/oozie/service/WorkflowAppService.java
+++ b/core/src/main/java/org/apache/oozie/service/WorkflowAppService.java
@@ -20,8 +20,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.oozie.client.OozieClient;
-import org.apache.oozie.client.XOozieClient;
-import org.apache.oozie.command.CommandException;
 import org.apache.oozie.workflow.WorkflowApp;
 import org.apache.oozie.workflow.WorkflowException;
 import org.apache.oozie.util.IOUtils;
@@ -118,10 +116,12 @@ public abstract class WorkflowAppService implements Service {
      *
      * @param jobConf job configuration.
      * @param authToken authentication token.
+     * @param isWorkflowJob indicates if the job is a workflow job or not.
      * @return proto configuration.
      * @throws WorkflowException thrown if the proto action configuration could not be created.
      */
-    public XConfiguration createProtoActionConf(Configuration jobConf, String authToken) throws WorkflowException {
+    public XConfiguration createProtoActionConf(Configuration jobConf, String authToken, boolean isWorkflowJob)
+            throws WorkflowException {
         XConfiguration conf = new XConfiguration();
         try {
             String user = jobConf.get(OozieClient.USER_NAME);
@@ -142,14 +142,20 @@ public abstract class WorkflowAppService implements Service {
             FileSystem fs = Services.get().get(HadoopAccessorService.class).createFileSystem(user, group, uri, conf);
 
             Path appPath = new Path(uri.getPath());
-            XLog.getLog(getClass()).debug("jobConf.libPath = " + jobConf.get(XOozieClient.LIBPATH));
+            XLog.getLog(getClass()).debug("jobConf.libPath = " + jobConf.get(OozieClient.LIBPATH));
             XLog.getLog(getClass()).debug("jobConf.appPath = " + appPath);
 
             List<String> filePaths = null;
-            if (jobConf.get(XOozieClient.LIBPATH) != null) { // This is a HTTP submission job;
-                filePaths = getLibFiles(fs, appPath);
-            } else {
+            if (isWorkflowJob) {
                 filePaths = getLibFiles(fs, new Path(appPath + "/lib"));
+                if (jobConf.get(OozieClient.LIBPATH) != null) {
+                    Path libPath = new Path(jobConf.get(OozieClient.LIBPATH));
+                    List<String> libPaths = getLibFiles(fs, libPath);
+                    filePaths.addAll(libPaths);
+                }
+            }
+            else {
+                filePaths = getLibFiles(fs, appPath);
             }
 
             conf.setStrings(APP_LIB_PATH_LIST, filePaths.toArray(new String[filePaths.size()]));

--- a/core/src/main/java/org/apache/oozie/servlet/BaseJobServlet.java
+++ b/core/src/main/java/org/apache/oozie/servlet/BaseJobServlet.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.oozie.BaseEngineException;
 import org.apache.oozie.ErrorCode;
 import org.apache.oozie.client.OozieClient;
-import org.apache.oozie.client.XOozieClient;
 import org.apache.oozie.client.rest.JsonBean;
 import org.apache.oozie.client.rest.RestConstants;
 import org.apache.oozie.service.AuthorizationException;
@@ -154,7 +153,7 @@ public abstract class BaseJobServlet extends JsonRestServlet {
             String wfPath = conf.get(OozieClient.APP_PATH);
             String coordPath = conf.get(OozieClient.COORDINATOR_APP_PATH);
             if (wfPath == null && coordPath == null) {
-                String libPath = conf.get(XOozieClient.LIBPATH);
+                String libPath = conf.get(OozieClient.LIBPATH);
                 conf.set(OozieClient.APP_PATH, libPath);
                 wfPath = libPath;
             }

--- a/core/src/test/java/org/apache/oozie/client/TestWorkflowXClient.java
+++ b/core/src/test/java/org/apache/oozie/client/TestWorkflowXClient.java
@@ -16,17 +16,12 @@ package org.apache.oozie.client;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
-import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
 import org.apache.hadoop.fs.Path;
-import org.apache.oozie.BuildInfo;
-import org.apache.oozie.client.OozieClient.SYSTEM_MODE;
-import org.apache.oozie.client.rest.RestConstants;
 import org.apache.oozie.servlet.DagServletTestCase;
 import org.apache.oozie.servlet.MockDagEngineService;
-import org.apache.oozie.servlet.V0JobServlet;
 import org.apache.oozie.servlet.V1JobsServlet;
 import org.apache.oozie.servlet.V1AdminServlet;
 
@@ -58,7 +53,7 @@ public class TestWorkflowXClient extends DagServletTestCase {
                 Properties conf = wc.createConfiguration();
                 Path libPath = new Path(getFsTestCaseDir(), "lib");
                 getFileSystem().mkdirs(libPath);
-                conf.setProperty(XOozieClient.LIBPATH, libPath.toString());
+                conf.setProperty(OozieClient.LIBPATH, libPath.toString());
                 conf.setProperty(XOozieClient.JT, "localhost:9001");
                 conf.setProperty(XOozieClient.NN, "hdfs://localhost:9000");
 
@@ -85,7 +80,7 @@ public class TestWorkflowXClient extends DagServletTestCase {
                 Properties conf = wc.createConfiguration();
                 Path libPath = new Path(getFsTestCaseDir(), "lib");
                 getFileSystem().mkdirs(libPath);
-                conf.setProperty(XOozieClient.LIBPATH, libPath.toString());
+                conf.setProperty(OozieClient.LIBPATH, libPath.toString());
                 conf.setProperty(XOozieClient.JT, "localhost:9001");
                 conf.setProperty(XOozieClient.NN, "hdfs://localhost:9000");
 

--- a/core/src/test/java/org/apache/oozie/command/wf/TestSubmitMRCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/wf/TestSubmitMRCommand.java
@@ -16,6 +16,7 @@ package org.apache.oozie.command.wf;
 
 import junit.framework.Assert;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.oozie.client.OozieClient;
 import org.apache.oozie.local.LocalOozie;
 import org.apache.oozie.client.XOozieClient;
 import org.apache.oozie.test.XFsTestCase;
@@ -43,7 +44,7 @@ public class TestSubmitMRCommand extends XFsTestCase {
 
         conf.set(XOozieClient.JT, "jobtracker");
         conf.set(XOozieClient.NN, "namenode");
-        conf.set(XOozieClient.LIBPATH, "libpath");
+        conf.set(OozieClient.LIBPATH, "libpath");
 
         conf.set("mapred.mapper.class", "A.Mapper");
         conf.set("mapred.reducer.class", "A.Reducer");

--- a/core/src/test/java/org/apache/oozie/command/wf/TestSubmitPigCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/wf/TestSubmitPigCommand.java
@@ -16,6 +16,7 @@ package org.apache.oozie.command.wf;
 
 import junit.framework.Assert;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.oozie.client.OozieClient;
 import org.apache.oozie.local.LocalOozie;
 import org.apache.oozie.action.hadoop.MapReduceMain;
 import org.apache.oozie.client.XOozieClient;
@@ -44,7 +45,7 @@ public class TestSubmitPigCommand extends XFsTestCase {
 
         conf.set(XOozieClient.JT, "jobtracker");
         conf.set(XOozieClient.NN, "namenode");
-        conf.set(XOozieClient.LIBPATH, "libpath");
+        conf.set(OozieClient.LIBPATH, "libpath");
 
         conf.set(XOozieClient.FILES, "/user/oozie/input1.txt,/user/oozie/input2.txt#my.txt");
         conf.set(XOozieClient.ARCHIVES, "/user/oozie/udf1.jar,/user/oozie/udf2.jar#my.jar");
@@ -111,7 +112,7 @@ public class TestSubmitPigCommand extends XFsTestCase {
 
         conf.set(XOozieClient.JT, "jobtracker");
         conf.set(XOozieClient.NN, "namenode");
-        conf.set(XOozieClient.LIBPATH, "libpath");
+        conf.set(OozieClient.LIBPATH, "libpath");
 
         conf.set(XOozieClient.FILES, "/user/oozie/input1.txt,/user/oozie/input2.txt");
         conf.set(XOozieClient.ARCHIVES, "/user/oozie/udf1.jar,/user/oozie/udf2.jar");

--- a/core/src/test/java/org/apache/oozie/service/TestActionCheckerService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestActionCheckerService.java
@@ -318,7 +318,7 @@ public class TestActionCheckerService extends XTestCase {
 
     private WorkflowJobBean createWorkflow(WorkflowApp app, Configuration conf, String authToken) throws Exception {
         WorkflowAppService wps = Services.get().get(WorkflowAppService.class);
-        Configuration protoActionConf = wps.createProtoActionConf(conf, authToken);
+        Configuration protoActionConf = wps.createProtoActionConf(conf, authToken, true);
         WorkflowLib workflowLib = Services.get().get(WorkflowStoreService.class).getWorkflowLibWithNoDB();
         WorkflowInstance wfInstance;
         wfInstance = workflowLib.createInstance(app, conf);

--- a/core/src/test/java/org/apache/oozie/service/TestLiteWorkflowAppService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestLiteWorkflowAppService.java
@@ -20,8 +20,6 @@ import org.apache.oozie.client.WorkflowAction;
 import org.apache.oozie.workflow.WorkflowApp;
 import org.apache.oozie.workflow.WorkflowException;
 import org.apache.oozie.workflow.lite.LiteWorkflowApp;
-import org.apache.oozie.service.Services;
-import org.apache.oozie.service.WorkflowAppService;
 import org.apache.oozie.test.XTestCase;
 import org.apache.oozie.util.IOUtils;
 import org.apache.oozie.util.XConfiguration;
@@ -32,6 +30,9 @@ import org.apache.oozie.ErrorCode;
 import java.io.FileWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import junit.framework.Assert;
 
@@ -280,7 +281,7 @@ public class TestLiteWorkflowAppService extends XTestCase {
         jobConf.set(OozieClient.USER_NAME, getTestUser());
         jobConf.set(OozieClient.GROUP_NAME, getTestGroup());
         injectKerberosInfo(jobConf);
-        Configuration protoConf = wps.createProtoActionConf(jobConf, "authToken");
+        Configuration protoConf = wps.createProtoActionConf(jobConf, "authToken", true);
         assertEquals(getTestUser(), protoConf.get(OozieClient.USER_NAME));
         assertEquals(getTestGroup(), protoConf.get(OozieClient.GROUP_NAME));
 
@@ -293,4 +294,48 @@ public class TestLiteWorkflowAppService extends XTestCase {
         Assert.assertTrue(f2.equals(ref1) || f2.equals(ref2));
         Assert.assertTrue(!f1.equals(f2));
     }
+
+    public void testCreateprotoConfWithLibPath() throws Exception {
+        Reader reader = IOUtils.getResourceAsReader("wf-schema-valid.xml", -1);
+        Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
+        IOUtils.copyCharStream(reader, writer);
+
+        createTestCaseSubDir("lib");
+        writer = new FileWriter(getTestCaseDir() + "/lib/maputil.jar");
+        writer.write("bla bla");
+        writer.close();
+        writer = new FileWriter(getTestCaseDir() + "/lib/reduceutil.so");
+        writer.write("bla bla");
+        writer.close();
+        createTestCaseSubDir("libx");
+        writer = new FileWriter(getTestCaseDir() + "/libx/maputilx.jar");
+        writer.write("bla bla");
+        writer.close();
+        Services services = new Services();
+        services.init();
+        WorkflowAppService wps = services.get(WorkflowAppService.class);
+        Configuration jobConf = new XConfiguration();
+        jobConf.set(OozieClient.APP_PATH, "file://" + getTestCaseDir());
+        jobConf.set(OozieClient.LIBPATH, "file://" + getTestCaseDir() + "/libx");
+        jobConf.set(OozieClient.USER_NAME, getTestUser());
+        jobConf.set(OozieClient.GROUP_NAME, getTestGroup());
+        injectKerberosInfo(jobConf);
+        Configuration protoConf = wps.createProtoActionConf(jobConf, "authToken", true);
+        assertEquals(getTestUser(), protoConf.get(OozieClient.USER_NAME));
+        assertEquals(getTestGroup(), protoConf.get(OozieClient.GROUP_NAME));
+
+        assertEquals(3, protoConf.getStrings(WorkflowAppService.APP_LIB_PATH_LIST).length);
+        List<String> found = new ArrayList<String>();
+        found.add(protoConf.getStrings(WorkflowAppService.APP_LIB_PATH_LIST)[0]);
+        found.add(protoConf.getStrings(WorkflowAppService.APP_LIB_PATH_LIST)[1]);
+        found.add(protoConf.getStrings(WorkflowAppService.APP_LIB_PATH_LIST)[2]);
+        List<String> expected = new ArrayList<String>();
+        expected.add(getTestCaseDir() + "/lib/reduceutil.so");
+        expected.add(getTestCaseDir() + "/lib/maputil.jar");
+        expected.add(getTestCaseDir() + "/libx/maputilx.jar");
+        Collections.sort(found);
+        Collections.sort(expected);
+        assertEquals(expected, found);
+    }
+
 }

--- a/core/src/test/java/org/apache/oozie/store/TestDBWorkflowStore.java
+++ b/core/src/test/java/org/apache/oozie/store/TestDBWorkflowStore.java
@@ -93,7 +93,7 @@ public class TestDBWorkflowStore extends XTestCase {
 
     private WorkflowJobBean createWorkflow(WorkflowApp app, Configuration conf, String authToken) throws Exception {
         WorkflowAppService wps = Services.get().get(WorkflowAppService.class);
-        Configuration protoActionConf = wps.createProtoActionConf(conf, authToken);
+        Configuration protoActionConf = wps.createProtoActionConf(conf, authToken, true);
         WorkflowLib workflowLib = Services.get().get(WorkflowStoreService.class).getWorkflowLibWithNoDB();
         WorkflowInstance wfInstance;
         wfInstance = workflowLib.createInstance(app, conf);

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,3 +1,11 @@
+-- Oozie 2.3.0 release
+
+- GH-0027 support for a share lib directory in HDFS for workflow action binaries
+
+-- Oozie 2.2.2 release
+
+-- Oozie 2.2.1 release
+
 -- Oozie 2.2.0 release
 
 - adding Pig version number to pig execution log in launcher log


### PR DESCRIPTION
this patch will effectively allow to have the Pig/Streaming and other commonly used JARs by multiple workflow apps once in a common directory in HDFS (a la /usr/share) and not in each workflow application (or referred one by one with <file> tags)
