### PR TITLE
Gh 0265

### DIFF
--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -179,12 +179,12 @@ public class OozieCLI {
     protected Options createJobOptions() {
         Option oozie = new Option(OOZIE_OPTION, true, "Oozie URL");
         Option config = new Option(CONFIG_OPTION, true, "job configuration file '.xml' or '.properties'");
-        Option submit = new Option(SUBMIT_OPTION, false, "submit a job (requires -config)");
-        Option run = new Option(RUN_OPTION, false, "run a job    (requires -config)");
+        Option submit = new Option(SUBMIT_OPTION, false, "submit a job");
+        Option run = new Option(RUN_OPTION, false, "run a job");
         Option rerun = new Option(RERUN_OPTION, true,
-                "rerun a job  (workflow requires -config, coordinator requires -action or -date)");
+                "rerun a job  (coordinator requires -action or -date)");
         Option dryrun = new Option(DRYRUN_OPTION, false,
-                "Supported in Oozie-2.0 or later versions ONLY - dryrun or test run a coordinator job (requires -config) - job is not queued");
+                "Supported in Oozie-2.0 or later versions ONLY - dryrun or test run a coordinator job, job is not queued");
         Option start = new Option(START_OPTION, true, "start a job");
         Option suspend = new Option(SUSPEND_OPTION, true, "suspend a job");
         Option resume = new Option(RESUME_OPTION, true, "resume a job");

--- a/core/src/main/conf/oozie-site.xml
+++ b/core/src/main/conf/oozie-site.xml
@@ -18,8 +18,228 @@
 
 <!--
     Refer to the oozie-default.xml file for the complete list of
-    Oozie configuration properties and their default values
+    Oozie configuration properties and their default values.
 -->
+
+    <property>
+        <name>oozie.system.id</name>
+        <value>oozie-${user.name}</value>
+        <description>
+            The Oozie system ID.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.systemmode</name>
+        <value>NORMAL</value>
+        <description>
+            System mode for  Oozie at startup.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.AuthorizationService.security.enabled</name>
+        <value>false</value>
+        <description>
+            Specifies whether security (user name/admin role) is enabled or not.
+            If disabled any user can manage Oozie system and manage any job.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.PurgeService.older.than</name>
+        <value>30</value>
+        <description>
+            Jobs older than this value, in days, will be purged by the PurgeService.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.PurgeService.purge.interval</name>
+        <value>3600</value>
+        <description>
+            Interval at which the purge service will run, in seconds.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.CallableQueueService.queue.size</name>
+        <value>1000</value>
+        <description>Max callable queue size</description>
+    </property>
+
+    <property>
+        <name>oozie.service.CallableQueueService.threads</name>
+        <value>10</value>
+        <description>Number of threads used for executing callables</description>
+    </property>
+
+    <property>
+        <name>oozie.service.CallableQueueService.callable.concurrency</name>
+        <value>3</value>
+        <description>
+            Maximum concurrency for a given callable type.
+            Each command is a callable type (submit, start, run, signal, job, jobs, suspend,resume, etc).
+            Each action type is a callable type (Map-Reduce, Pig, SSH, FS, sub-workflow, etc).
+            All commands that use action executors (action-start, action-end, action-kill and action-check) use
+            the action type as the callable type.
+        </description>
+    </property>
+
+    <property>
+		<name>oozie.service.coord.normal.default.timeout
+		</name>
+		<value>120</value>
+		<description>Default timeout for a coordinator action input check (in minutes) for normal job.
+            -1 means infinite timeout</description>
+	</property>
+
+    <property>
+        <name>oozie.db.schema.name</name>
+        <value>oozie</value>
+        <description>
+            Oozie DataBase Name
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.StoreService.create.db.schema</name>
+        <value>true</value>
+        <description>
+            Creates Oozie DB.
+
+            If set to true, it creates the DB schema if it does not exist. If the DB schema exists is a NOP.
+            If set to false, it does not create the DB schema. If the DB schema does not exist it fails start up.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.StoreService.jdbc.driver</name>
+        <value>org.apache.derby.jdbc.EmbeddedDriver</value>
+        <description>
+            JDBC driver class.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.StoreService.jdbc.url</name>
+        <value>jdbc:derby:${oozie.home.dir}/${oozie.db.schema.name}-db;create=true</value>
+        <description>
+            JDBC URL.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.StoreService.jdbc.username</name>
+        <value>sa</value>
+        <description>
+            DB user name.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.StoreService.jdbc.password</name>
+        <value> </value>
+        <description>
+            DB user password.
+
+            IMPORTANT: if password is emtpy leave a 1 space string, the service trims the value,
+                       if empty Configuration assumes it is NULL.
+
+            IMPORTANT: if the StoreServicePasswordService is active, it will reset this value with the value given in
+                       the console.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.StoreService.pool.max.active.conn</name>
+        <value>10</value>
+        <description>
+             Max number of connections.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.ActionService.executor.ext.classes</name>
+        <value>
+            org.apache.oozie.action.hadoop.HiveActionExecutor,
+            org.apache.oozie.action.hadoop.SqoopActionExecutor
+        </value>
+    </property>
+
+    <property>
+        <name>oozie.service.SchemaService.wf.ext.schemas</name>
+        <value>hive-action-0.2.xsd,sqoop-action-0.1.xsd</value>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.kerberos.enabled</name>
+        <value>false</value>
+        <description>
+            Indicates if Oozie is configured to use Kerberos.
+        </description>
+    </property>
+
+    <property>
+        <name>local.realm</name>
+        <value>LOCALHOST</value>
+        <description>
+            Kerberos Realm used by Oozie and Hadoop. Using 'local.realm' to be aligned with Hadoop configuration
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.keytab.file</name>
+        <value>${user.home}/oozie.keytab</value>
+        <description>
+            Location of the Oozie user keytab file.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.kerberos.principal</name>
+        <value>${user.name}/localhost@${local.realm}</value>
+        <description>
+            Kerberos principal for Oozie service.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.jobTracker.whitelist</name>
+        <value> </value>
+        <description>
+            Whitelisted job tracker for Oozie service.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.HadoopAccessorService.nameNode.whitelist</name>
+        <value> </value>
+        <description>
+            Whitelisted job tracker for Oozie service.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.service.WorkflowAppService.system.libpath</name>
+        <value>/user/${user.name}/share/lib</value>
+        <description>
+            System library path to use for workflow applications.
+            This path is added to workflow application if their job properties sets
+            the property 'oozie.use.system.libpath' to true.
+        </description>
+    </property>
+
+    <property>
+        <name>use.system.libpath.for.mapreduce.and.pig.jobs</name>
+        <value>false</value>
+        <description>
+            If set to true, submissions of MapReduce and Pig jobs will include
+            automatically the system library path, thus not requiring users to
+            specify where the Pig JAR files are. Instead, the ones from the system
+            library path are used.
+        </description>
+    </property>
 
 </configuration>
 

--- a/core/src/main/conf/oozie-site.xml
+++ b/core/src/main/conf/oozie-site.xml
@@ -160,19 +160,6 @@
     </property>
 
     <property>
-        <name>oozie.service.ActionService.executor.ext.classes</name>
-        <value>
-            org.apache.oozie.action.hadoop.HiveActionExecutor,
-            org.apache.oozie.action.hadoop.SqoopActionExecutor
-        </value>
-    </property>
-
-    <property>
-        <name>oozie.service.SchemaService.wf.ext.schemas</name>
-        <value>hive-action-0.2.xsd,sqoop-action-0.1.xsd</value>
-    </property>
-
-    <property>
         <name>oozie.service.HadoopAccessorService.kerberos.enabled</name>
         <value>false</value>
         <description>

--- a/core/src/main/java/org/apache/oozie/service/WorkflowAppService.java
+++ b/core/src/main/java/org/apache/oozie/service/WorkflowAppService.java
@@ -143,10 +143,8 @@ public abstract class WorkflowAppService implements Service {
             conf.set(OozieClient.GROUP_NAME, group);
             conf.set(HADOOP_UGI, hadoopUgi);
 
-            if (Services.get().getConf().getBoolean("oozie.service.HadoopAccessorService.kerberos.enabled", false)) {
-                conf.set(HADOOP_JT_KERBEROS_NAME, jobConf.get(HADOOP_JT_KERBEROS_NAME));
-                conf.set(HADOOP_NN_KERBEROS_NAME, jobConf.get(HADOOP_NN_KERBEROS_NAME));
-            }
+            conf.set(HADOOP_JT_KERBEROS_NAME, jobConf.get(HADOOP_JT_KERBEROS_NAME));
+            conf.set(HADOOP_NN_KERBEROS_NAME, jobConf.get(HADOOP_NN_KERBEROS_NAME));
 
             URI uri = new URI(jobConf.get(OozieClient.APP_PATH));
 

--- a/core/src/test/java/org/apache/oozie/util/TestXConfiguration.java
+++ b/core/src/test/java/org/apache/oozie/util/TestXConfiguration.java
@@ -111,4 +111,25 @@ public class TestXConfiguration extends XTestCase {
         assertEquals("A", conf.getRaw("b"));
     }
 
+    public void testVarResolutionAndSysProps() {
+        setSystemProperty("aa", "foo");
+        XConfiguration conf = new XConfiguration();
+        conf.set("a", "A");
+        conf.set("b", "${a}");
+        conf.set("c", "${aa}");
+        conf.set("d", "${aaa}");
+        assertEquals("A", conf.getRaw("a"));
+        assertEquals("${a}", conf.getRaw("b"));
+        assertEquals("${aa}", conf.getRaw("c"));
+        assertEquals("A", conf.get("a"));
+        assertEquals("A", conf.get("b"));
+        assertEquals("foo", conf.get("c"));
+        assertEquals("${aaa}", conf.get("d"));
+
+        conf.set("un","${user.name}");
+        assertEquals(System.getProperty("user.name"), conf.get("un"));
+        setSystemProperty("user.name", "foo");
+        assertEquals("foo", conf.get("un"));
+
+    }
 }

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -59,23 +59,6 @@
         </plugins>
     </build>
 
-    <reporting>
-        <plugins>
-             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                 <!-- Don't change version as doc generation may fail -->
-                <version>2.0-beta-3</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-        </plugins>
-    </reporting>
-
     <profiles>
         <profile>
             <id>generateDocs</id>
@@ -85,25 +68,40 @@
                     <name>generateDocs</name>
                 </property>
             </activation>
+            <reporting>
+                <plugins>
+                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-project-info-reports-plugin</artifactId>
+                         <!-- Using version because plugin management does not work for reporting plugins -->
+                         <version>2.2</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
             <build>
                 <plugins>
-                    <!-- Customized Doxia Maven Plugin for twiki documentation -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-site-plugin</artifactId>
-                        <!-- Don't change version as doc generation may fail -->
-                        <version>2.0-beta-6</version>
                         <configuration>
                             <port>8888</port>
                             <outputEncoding>UTF-8</outputEncoding>
                         </configuration>
                         <dependencies>
                             <dependency>
+                                <!-- Customized Doxia Maven Plugin for twiki documentation -->
                                 <groupId>org.apache.maven.doxia</groupId>
                                 <artifactId>doxia-module-twiki</artifactId>
                                 <version>1.0-alpha-9.2y</version>
                             </dependency>
                             <dependency>
+                                <!-- Customized Doxia Maven Plugin for twiki documentation -->
                                 <groupId>org.apache.maven.doxia</groupId>
                                 <artifactId>doxia-core</artifactId>
                                 <version>1.0-alpha-9.2y</version>

--- a/docs/src/site/twiki/DG_CommandLineTool.twiki
+++ b/docs/src/site/twiki/DG_CommandLineTool.twiki
@@ -16,7 +16,7 @@ The =oozie= CLI interacts with Oozie via its WS API.
 ---++ Oozie Command Line Usage
 
 <verbatim>
-  usage:
+usage:
       the env variable 'OOZIE_URL' is used as default value for the '-oozie' option
       custom headers for Oozie web services can be specified using '-Dheader:NAME=VALUE'
 
@@ -25,32 +25,33 @@ The =oozie= CLI interacts with Oozie via its WS API.
       oozie version : show client version
 
       oozie job <OPTIONS> : job operations
-                -action <arg>       coordinator rerun on action ids (requires -rerun)
-                -change <arg>       change a coordinator job
-                -config <arg>       job configuration file '.xml' or '.properties'
-                -date <arg>         coordinator rerun on action dates (requires -rerun)
-                -definition <arg>   job definition
-                -dryrun             Supported in Oozie-2.0 or later versions ONLY - dryrun or test
-                                    run a coordinator job (requires -config) - job is not queued
-                -info <arg>         info of a job
-                -kill <arg>         kill a job
-                -len <arg>          number of actions (default TOTAL ACTIONS, requires -info)
-                -localtime          use local time (default GMT)
-                -log <arg>          job log
-                -nocleanup          do not clean up output-events of the coordiantor rerun actions
-                                    (requires -rerun)
-                -offset <arg>       job info offset of actions (default '1', requires -info)
-                -oozie <arg>        Oozie URL
-                -refresh            re-materialize the coordinator rerun actions (requires -rerun)
-                -rerun <arg>        rerun a job  (workflow requires -config, coordinator requires
-                                    -action or -date)
-                -resume <arg>       resume a job
-                -run                run a job    (requires -config)
-                -start <arg>        start a job
-                -submit             submit a job (requires -config)
-                -suspend <arg>      suspend a job
-                -value <arg>        new endtime/concurrency/pausetime value for changing a coordinator job
-                -verbose            verbose mode
+                -action <arg>         coordinator rerun on action ids (requires -rerun)
+                -change <arg>         change a coordinator job
+                -config <arg>         job configuration file '.xml' or '.properties'
+                -D <property=value>   set/override value for given property
+                -date <arg>           coordinator rerun on action dates (requires -rerun)
+                -definition <arg>     job definition
+                -dryrun               Supported in Oozie-2.0 or later versions ONLY - dryrun or test
+                                      run a coordinator job, job is not queued
+                -info <arg>           info of a job
+                -kill <arg>           kill a job
+                -len <arg>            number of actions (default TOTAL ACTIONS, requires -info)
+                -localtime            use local time (default GMT)
+                -log <arg>            job log
+                -nocleanup            do not clean up output-events of the coordiantor rerun actions
+                                      (requires -rerun)
+                -offset <arg>         job info offset of actions (default '1', requires -info)
+                -oozie <arg>          Oozie URL
+                -refresh              re-materialize the coordinator rerun actions (requires -rerun)
+                -rerun <arg>          rerun a job  (coordinator requires -action or -date)
+                -resume <arg>         resume a job
+                -run                  run a job
+                -start <arg>          start a job
+                -submit               submit a job
+                -suspend <arg>        suspend a job
+                -value <arg>          new endtime/concurrency/pausetime value for changing a
+                                      coordinator job
+                -verbose              verbose mode
 
       oozie jobs <OPTIONS> : jobs status
                  -filter <arg>    user=<U>;name=<N>;group=<G>;status=<S>;...
@@ -78,9 +79,10 @@ The =oozie= CLI interacts with Oozie via its WS API.
                 -oozie <arg>    Oozie URL
 
       oozie pig <OPTIONS> -X <ARGS> : submit a pig job, everything after '-X' are pass-through parameters to pig
-                -config <arg>   job configuration file '.properties'
-                -file <arg>     Pig script
-                -oozie <arg>    Oozie URL
+                -config <arg>         job configuration file '.properties'
+                -D <property=value>   set/override value for given property
+                -file <arg>           Pig script
+                -oozie <arg>          Oozie URL
 </verbatim>
 
 ---++ Common CLI Options

--- a/docs/src/site/twiki/ENG_Building.twiki
+++ b/docs/src/site/twiki/ENG_Building.twiki
@@ -146,6 +146,30 @@ testcases.
 *oozie.test.kerberos.namenode.principal*= : indicates the Kerberos principal for the NameNode, default value
 'hdfs/localhost'
 
+*oozie.test.user.oozie*= : specifies the user ID used to start Oozie server in testcases, default value
+is =${user.name}=.
+
+*oozie.test.user.test*= : specifies primary user ID used as the user submitting jobs to Oozie Server in testcases,
+default value is =test=.
+
+*oozie.test.user.test2*= : specifies secondary user ID used as the user submitting jobs to Oozie Server in testcases,
+default value is =test2=.
+
+*oozie.test.user.test3*= : specifies secondary user ID used as the user submitting jobs to Oozie Server in testcases,
+default value is =test2=.
+
+*oozie.test.group*= : specifies group ID used as group when submitting jobs to Oozie Server in testcases,
+default value is =test2=.
+
+NOTE: The users/group specified in *oozie.test.user.test2*, *oozie.test.user.test3*= and *oozie.test.user.group*=
+are used for the authorization testcases only.
+
+*oozie.test.dir*= : specifies the directory where the =oozietests= directory will be created, default value is =/tmp=.
+The =oozietests= directory is used by testcases when they need a local filesystem directory.
+
+*hadoop.log.dir*= : specifies the directory where Hadoop minicluster will write its logs during testcases, default
+value is =/tmp=.
+
 ---++ Building an Oozie Distribution
 
 An Oozie distribution bundles an embedded Tomcat server. The Oozie distro module downloads Tomcat TAR.GZ from Apache

--- a/docs/src/site/twiki/ENG_Building.twiki
+++ b/docs/src/site/twiki/ENG_Building.twiki
@@ -10,7 +10,7 @@
 
    * Unix box (tested on Mac OS X and Linux)
    * Java JDK 1.6+
-   * [[http://archive.apache.org/dist/maven/binaries/apache-maven-2.2.0-bin.tar.gz][Maven 2.2.0]]
+   * [[http://maven.apache.org/][Maven 3.0.1+]]
    * [[http://hadoop.apache.org/core/releases.html][Hadoop 0.20.2+]]
    * [[http://hadoop.apache.org/pig/releases.html][Pig 0.7+]]
 
@@ -93,6 +93,11 @@ $ mvn clean test -Dmysql -Doozie.test.config.file=/home/tucu/oozie-site-mysql.xm
 </verbatim>
 
 ---+++ Build Options Reference
+
+All these options are set using *-D*.
+
+*includeHadoopJars* : includes Hadoop JARs and its transitive dependencies in the Oozie WAR file, default is
+undefined (Hadoop JARs are not included).
 
 *generateSite* : generates Oozie documentation, default is undefined (no documentation is generated)
 

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,11 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                 </plugin>
@@ -456,10 +461,68 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.6</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <!-- Don't change version as doc generation may fail -->
+                    <!-- (using custom doxia for twiki pages generation) -->
+                    <version>2.0-beta-6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>2.2</version>                    
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>2.1</version>                    
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <rules>
+                        <requireMavenVersion>
+                            <version>[3.0.0,)</version>
+                        </requireMavenVersion>
+                        <requireJavaVersion>
+                            <version>1.6</version>
+                        </requireJavaVersion>
+                        <requireOS>
+                            <family>unix</family>
+                        </requireOS>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>clean</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>pre-clean</phase>
+                    </execution>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                    <execution>
+                         <id>site</id>
+                         <goals>
+                             <goal>enforce</goal>
+                         </goals>
+                         <phase>pre-site</phase>
+                     </execution>
+                 </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.0 release
 
+GH-0246 Move build to use Maven 3, fix issues in POMs
 GH-0048 Update CoordinatorFunctionalSpec with done-flag examples
 GH-0064 Create a config to turn on openjpa log
 GH-0238 it should be possible to submit oozie pig jobs using the system library by default

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.0 release
 
+GH-0245 pre-populate oozie-site.xml with common props with default settings
 GH-0246 Move build to use Maven 3, fix issues in POMs
 GH-0048 Update CoordinatorFunctionalSpec with done-flag examples
 GH-0064 Create a config to turn on openjpa log

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.0 release
 
+GH-0251 ENG build docs should mention test properties settings
 GH-0245 pre-populate oozie-site.xml with common props with default settings
 GH-0246 Move build to use Maven 3, fix issues in POMs
 GH-0048 Update CoordinatorFunctionalSpec with done-flag examples

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.0 release
 
+GH-0262 WorkflowAppService should always inject Kerberos principal rules regardless of Kerberos/Simple auth
 GH-0254 XConfiguration should give precedence to variables over sys-props in ${} expressions
 GH-0251 ENG build docs should mention test properties settings
 GH-0245 pre-populate oozie-site.xml with common props with default settings

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.0 release
 
+GH-0254 XConfiguration should give precedence to variables over sys-props in ${} expressions
 GH-0251 ENG build docs should mention test properties settings
 GH-0245 pre-populate oozie-site.xml with common props with default settings
 GH-0246 Move build to use Maven 3, fix issues in POMs

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.0 release
 
+GH-0265 Oozie CLI and docs have not been updated to reflect that -config is now optional
 GH-0262 WorkflowAppService should always inject Kerberos principal rules regardless of Kerberos/Simple auth
 GH-0254 XConfiguration should give precedence to variables over sys-props in ${} expressions
 GH-0251 ENG build docs should mention test properties settings

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -123,25 +123,81 @@
         </plugins>
     </build>
 
-    <reporting>
-        <plugins>
-             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                 <!-- Don't change version as doc generation may fail -->
-                <version>2.0-beta-3</version>
-                 <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>dependencies</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-        </plugins>
-    </reporting>
-
     <profiles>
+        <profile>
+            <id>includeHadoopJars</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>includeHadoopJars</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.yahoo.hadoop</groupId>
+                    <artifactId>hadoop-core</artifactId>
+                    <scope>compile</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>commons-cli</groupId>
+                            <artifactId>commons-cli</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>commons-httpclient</groupId>
+                            <artifactId>commons-httpclient</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>tomcat</groupId>
+                            <artifactId>jasper-compiler</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>tomcat</groupId>
+                            <artifactId>jasper-runtime</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>javax.servlet</groupId>
+                            <artifactId>servlet-api</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>javax.servlet</groupId>
+                            <artifactId>jsp-api</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-log4j12</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>commons-logging</groupId>
+                            <artifactId>commons-logging-api</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>jetty</groupId>
+                            <artifactId>org.mortbay.jetty</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.mortbay.jetty</groupId>
+                            <artifactId>jetty</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.mortbay.jetty</groupId>
+                            <artifactId>jetty-util</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.mortbay.jetty</groupId>
+                            <artifactId>jsp-api-2.1</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.mortbay.jetty</groupId>
+                            <artifactId>servlet-api-2.5</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>generateDocs</id>
             <activation>
@@ -154,13 +210,14 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-site-plugin</artifactId>
-                        <!-- Don't change version as doc generation may fail -->
-                        <version>2.0-beta-6</version>
+                        <artifactId>maven-project-info-reports-plugin</artifactId>
                         <executions>
                             <execution>
+                                <configuration>
+                                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                                </configuration>
                                 <goals>
-                                    <goal>site</goal>
+                                    <goal>dependencies</goal>
                                 </goals>
                                 <phase>prepare-package</phase>
                             </execution>


### PR DESCRIPTION
Includes all outstanding PRs (already +1ed)

Closes GH-0265 Oozie CLI and docs have not been updated to reflect that -config is now optional
Closes GH-0262 WorkflowAppService should always inject Kerberos principal rules regardless of Kerberos/Simple auth
Closes GH-0254 XConfiguration should give precedence to variables over sys-props in ${} expressions
Closes GH-0251 ENG build docs should mention test properties settings
Closes GH-0245 pre-populate oozie-site.xml with common props with default settings
Closes GH-0245 pre-populate oozie-site.xml with common props with default settings
Closes GH-0246 Move build to use Maven 3, fix issues in POMs
