### PR TITLE
Gh 0035

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -58,6 +58,12 @@
             <artifactId>persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.cloudera.alfredo</groupId>
+            <artifactId>alfredo</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -169,6 +169,17 @@
             <scope>compile</scope>
         </dependency>
         
+        <dependency>
+            <groupId>com.cloudera.alfredo</groupId>
+            <artifactId>alfredo</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/conf/oozie-site.xml
+++ b/core/src/main/conf/oozie-site.xml
@@ -228,5 +228,59 @@
         </description>
     </property>
 
+    <property>
+        <name>oozie.authentication.type</name>
+        <value>simple</value>
+        <description>
+            Defines authentication used for Oozie HTTP endpoint.
+            Supported values are: simple | kerberos | #AUTHENTICATION_HANDLER_CLASSNAME#
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.token.validity</name>
+        <value>36000</value>
+        <description>
+            Indicates how long (in seconds) an authentication token is valid before it has
+            to be renewed.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.signature.secret</name>
+        <value></value>
+        <description>
+            The signature secret for signing the authentication tokens.
+            If not set a random secret is generated at startup time.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.simple.anonymous.allowed</name>
+        <value>true</value>
+        <description>
+            Indicates if anonymous requests are allowed.
+            This setting is meaningful only when using 'simple' authentication.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.kerberos.principal</name>
+        <value>HTTP/localhost@${local.realm}</value>
+        <description>
+            Indicates the Kerberos principal to be used for HTTP endpoint.
+            The principal MUST start with 'HTTP/' as per Kerberos HTTP SPNEGO specification.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.kerberos.keytab</name>
+        <value>${oozie.service.HadoopAccessorService.keytab.file}</value>
+        <description>
+            Location of the keytab file with the credentials for the principal.
+            Referring to the same keytab file Oozie uses for its Kerberos credentials for Hadoop.
+        </description>
+    </property>
+
 </configuration>
 

--- a/core/src/main/conf/oozie-site.xml
+++ b/core/src/main/conf/oozie-site.xml
@@ -252,7 +252,19 @@
         <description>
             The signature secret for signing the authentication tokens.
             If not set a random secret is generated at startup time.
+            In order to authentiation to work correctly across multiple hosts
+            the secret must be the same across al the hosts.
         </description>
+    </property>
+
+    <property>
+      <name>oozie.authentication.cookie.domain</name>
+      <value></value>
+      <description>
+        The domain to use for the HTTP cookie that stores the authentication token.
+        In order to authentiation to work correctly across multiple hosts
+        the domain must be correctly set.
+      </description>
     </property>
 
     <property>

--- a/core/src/main/java/org/apache/oozie/servlet/OozieAuthenticationFilter.java
+++ b/core/src/main/java/org/apache/oozie/servlet/OozieAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package org.apache.oozie.servlet;
+
+import com.cloudera.alfredo.server.AuthenticationFilter;
+import com.cloudera.alfredo.server.KerberosAuthenticationHandler;
+import com.cloudera.alfredo.server.PseudoAuthenticationHandler;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.oozie.service.Services;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import java.util.Properties;
+
+/**
+ *
+ */
+public class OozieAuthenticationFilter extends AuthenticationFilter {
+    private static final String OOZIE_PREFIX = "oozie.authentication.";
+
+    private static final String OOZIE_AUTH_TYPE = OOZIE_PREFIX + "type";
+    private static final String OOZIE_AUTH_TOKEN_VALIDITY = OOZIE_PREFIX + "token.validity";
+    private static final String OOZIE_SIGNATURE_SECRET = OOZIE_PREFIX + "signature.secret";
+
+    private static final String OOZIE_SIMPLE_ANONYMOUS_ALLOWED = OOZIE_PREFIX + "simple.anonymous.allowed";
+
+    private static final String OOZIE_KERBEROS_PRINCIPAL = OOZIE_PREFIX + "kerberos.principal";
+    private static final String OOZIE_KERBEROS_KEYTAB = OOZIE_PREFIX + "kerberos.keytab";
+
+    @Override
+    protected Properties getConfiguration(String configPrefix, FilterConfig filterConfig) throws ServletException {
+        Properties props = new Properties();
+        Configuration conf = Services.get().getConf();
+
+        String type = conf.get(OOZIE_AUTH_TYPE, PseudoAuthenticationHandler.TYPE);
+        props.setProperty(AUTH_TYPE, type);
+        props.setProperty(AUTH_TOKEN_VALIDITY, conf.get(OOZIE_AUTH_TOKEN_VALIDITY, "36000"));
+        props.setProperty(SIGNATURE_SECRET, conf.get(OOZIE_AUTH_TOKEN_VALIDITY, "36000"));
+        if (conf.get(OOZIE_SIGNATURE_SECRET) != null) {
+            props.setProperty(SIGNATURE_SECRET, conf.get(OOZIE_SIGNATURE_SECRET));
+        }
+
+        if (type.equals(PseudoAuthenticationHandler.TYPE)) {
+            props.setProperty(PseudoAuthenticationHandler.ANONYMOUS_ALLOWED,
+                              conf.get(OOZIE_SIMPLE_ANONYMOUS_ALLOWED, "true"));
+        }
+        else if (type.equals(KerberosAuthenticationHandler.TYPE)) {
+            props.setProperty(KerberosAuthenticationHandler.PRINCIPAL, conf.get(OOZIE_KERBEROS_PRINCIPAL));
+            props.setProperty(KerberosAuthenticationHandler.KEYTAB, conf.get(OOZIE_KERBEROS_KEYTAB));
+        }
+
+        return props;
+    }
+}

--- a/core/src/main/java/org/apache/oozie/servlet/OozieAuthenticationFilter.java
+++ b/core/src/main/java/org/apache/oozie/servlet/OozieAuthenticationFilter.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
 package org.apache.oozie.servlet;
 
 import com.cloudera.alfredo.server.AuthenticationFilter;
@@ -11,7 +25,8 @@ import javax.servlet.ServletException;
 import java.util.Properties;
 
 /**
- *
+ * Authentication filter that extends Alfredo AuthenticationFilter to override
+ * the configuration loading.
  */
 public class OozieAuthenticationFilter extends AuthenticationFilter {
     private static final String OOZIE_PREFIX = "oozie.authentication.";
@@ -19,6 +34,8 @@ public class OozieAuthenticationFilter extends AuthenticationFilter {
     private static final String OOZIE_AUTH_TYPE = OOZIE_PREFIX + "type";
     private static final String OOZIE_AUTH_TOKEN_VALIDITY = OOZIE_PREFIX + "token.validity";
     private static final String OOZIE_SIGNATURE_SECRET = OOZIE_PREFIX + "signature.secret";
+
+    private static final String OOZIE_COOKIE_DOMAIN = OOZIE_PREFIX + "cookie.domain";
 
     private static final String OOZIE_SIMPLE_ANONYMOUS_ALLOWED = OOZIE_PREFIX + "simple.anonymous.allowed";
 
@@ -32,11 +49,20 @@ public class OozieAuthenticationFilter extends AuthenticationFilter {
 
         String type = conf.get(OOZIE_AUTH_TYPE, PseudoAuthenticationHandler.TYPE);
         props.setProperty(AUTH_TYPE, type);
+
         props.setProperty(AUTH_TOKEN_VALIDITY, conf.get(OOZIE_AUTH_TOKEN_VALIDITY, "36000"));
+
         props.setProperty(SIGNATURE_SECRET, conf.get(OOZIE_AUTH_TOKEN_VALIDITY, "36000"));
+
         if (conf.get(OOZIE_SIGNATURE_SECRET) != null) {
             props.setProperty(SIGNATURE_SECRET, conf.get(OOZIE_SIGNATURE_SECRET));
         }
+
+        if (conf.get(OOZIE_COOKIE_DOMAIN) != null) {
+            props.setProperty(COOKIE_DOMAIN, conf.get(OOZIE_COOKIE_DOMAIN));
+        }
+
+        props.setProperty(COOKIE_PATH, "/");
 
         if (type.equals(PseudoAuthenticationHandler.TYPE)) {
             props.setProperty(PseudoAuthenticationHandler.ANONYMOUS_ALLOWED,

--- a/core/src/main/java/org/apache/oozie/test/EmbeddedServletContainer.java
+++ b/core/src/main/java/org/apache/oozie/test/EmbeddedServletContainer.java
@@ -15,6 +15,7 @@
 package org.apache.oozie.test;
 
 import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.FilterHolder;
 import org.mortbay.jetty.servlet.ServletHolder;
 import org.mortbay.jetty.servlet.Context;
 
@@ -44,6 +45,17 @@ public class EmbeddedServletContainer {
         context = new Context();
         context.setContextPath("/" + contextPath);
         server.setHandler(context);
+    }
+
+    /**
+     * Add a filter to the container.
+     *
+     * @param path path for the filter, it should be prefixed with '/", it may contain a wild card at
+     * the end.
+     * @param filterClass filter class
+     */
+    public void addFilter(String path, Class filterClass) {
+        context.addFilter(new FilterHolder(filterClass), "/*", 0);
     }
 
     /**

--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -1176,4 +1176,59 @@
         </description>
     </property>
 
+    <!-- Oozie Authentication -->
+
+    <property>
+        <name>oozie.authentication.type</name>
+        <value>simple</value>
+        <description>
+            Defines authentication used for Oozie HTTP endpoint.
+            Supported values are: simple | kerberos | #AUTHENTICATION_HANDLER_CLASSNAME#
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.token.validity</name>
+        <value>36000</value>
+        <description>
+            Indicates how long (in seconds) an authentication token is valid before it has
+            to be renewed.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.signature.secret</name>
+        <value></value>
+        <description>
+            The signature secret for signing the authentication tokens.
+            If not set a random secret is generated at startup time.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.simple.anonymous.allowed</name>
+        <value>true</value>
+        <description>
+            Indicates if anonymous requests are allowed when using 'simple' authentication.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.kerberos.principal</name>
+        <value>HTTP/localhost@${local.realm}</value>
+        <description>
+            Indicates the Kerberos principal to be used for HTTP endpoint.
+            The principal MUST start with 'HTTP/' as per Kerberos HTTP SPNEGO specification.
+        </description>
+    </property>
+
+    <property>
+        <name>oozie.authentication.kerberos.keytab</name>
+        <value>${oozie.service.HadoopAccessorService.keytab.file}</value>
+        <description>
+            Location of the keytab file with the credentials for the principal.
+            Referring to the same keytab file Oozie uses for its Kerberos credentials for Hadoop.
+        </description>
+    </property>
+
 </configuration>

--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -1202,7 +1202,19 @@
         <description>
             The signature secret for signing the authentication tokens.
             If not set a random secret is generated at startup time.
+            In order to authentiation to work correctly across multiple hosts
+            the secret must be the same across al the hosts.
         </description>
+    </property>
+
+    <property>
+      <name>oozie.authentication.cookie.domain</name>
+      <value></value>
+      <description>
+        The domain to use for the HTTP cookie that stores the authentication token.
+        In order to authentiation to work correctly across multiple hosts
+        the domain must be correctly set.
+      </description>
     </property>
 
     <property>

--- a/core/src/test/java/org/apache/oozie/servlet/DagServletTestCase.java
+++ b/core/src/test/java/org/apache/oozie/servlet/DagServletTestCase.java
@@ -59,11 +59,17 @@ public abstract class DagServletTestCase extends XFsTestCase {
     @SuppressWarnings("unchecked")
     protected void runTest(String servletPath, Class servletClass, boolean securityEnabled, Callable<Void> assertions)
             throws Exception {
-        runTest(new String[]{servletPath}, new Class[]{servletClass}, securityEnabled, assertions);
+        runTest(new String[]{servletPath}, new Class[]{servletClass}, new String[0], new Class[0], securityEnabled,
+                assertions);
     }
 
-    protected void runTest(String[] servletPath, Class[] servletClass, boolean securityEnabled,
-                           Callable<Void> assertions) throws Exception {
+    protected void runTest(String[] servletPath, Class[] servletClass,
+                           boolean securityEnabled, Callable<Void> assertions) throws Exception {
+        runTest(servletPath, servletClass, new String[0], new Class[0], securityEnabled, assertions);
+    }
+
+    protected void runTest(String[] servletPath, Class[] servletClass, String[] filterPath, Class[] filterClass,
+                           boolean securityEnabled, Callable<Void> assertions) throws Exception {
         Services services = new Services();
         this.servletPath = servletPath[0];
         try {
@@ -76,6 +82,9 @@ public abstract class DagServletTestCase extends XFsTestCase {
             container = new EmbeddedServletContainer("oozie");
             for (int i = 0; i < servletPath.length; i++) {
                 container.addServletEndpoint(servletPath[i], servletClass[i]);
+            }
+            for (int i = 0; i < filterPath.length; i++) {
+                container.addFilter(filterPath[i], filterClass[i]);
             }
             container.start();
             assertions.call();

--- a/docs/src/site/twiki/AG_Install.twiki
+++ b/docs/src/site/twiki/AG_Install.twiki
@@ -160,11 +160,59 @@ Oozie logs in 4 different files:
 
 The embedded Tomcat and embedded Derby log files are also written to Oozie's =logs/= directory.
 
----+++ Oozie Authentication Configuration
+---+++ Oozie User Authentication Configuration
+
+Oozie supports Kerberos HTTP SPNEGO authentication, pseudo/simple authentication and anonymous access
+for client connections.
+
+Anonymous access (*default*) does not require the user to authenticate and the user ID is obtained from
+the job properties on job submission operations, other operations are anonymous.
+
+Pseudo/simple authentication requires the user to specify the user name on the request, this must be done
+using the additional query string parameter =user.name=.
+
+Kerberos HTTP SPNEGO authentication requires the user to perform a Kerberos HTTP SPNEGO authentication sequence.
+
+If Pseudo/simple or Kerberos HTTP SPNEGO authentication mechanisms are used, Oozie will return the user an
+authentication token HTTP Cookie that can be used in later requests as identy proof.
+
+Oozie uses [[http://www.github.com/cloudera/alfredo][Alfredo, Java HTTP SPENGO]] library for authentication.
+This library can be extended to support other authentication mechanisms.
+
+Oozie user authentication is configured using the following configuration properties (default values shown):
+
+<verbatim>
+  oozie.authentication.type=simple
+  oozie.authentication.token.validity=36000
+  oozie.authentication.signature.secret=
+  oozie.authentication.simple.anonymous.allowed=true
+  oozie.authentication.kerberos.principal=HTTP/localhost@${local.realm}
+  oozie.authentication.kerberos.keytab=${oozie.service.HadoopAccessorService.keytab.file}
+</verbatim>
+
+The =type= defines authentication used for Oozie HTTP endpoint, the supported values are:
+simple | kerberos | #AUTHENTICATION_HANDLER_CLASSNAME#.
+
+The =token.validity= indicates how long (in seconds) an authentication token is valid before it has
+to be renewed.
+
+The =signature.secret= is the signature secret for signing the authentication tokens. If not set a random
+secret is generated at startup time.
+
+The =simple.anonymous.allowed= indicates if anonymous requests are allowed. This setting is meaningful
+only when using 'simple' authentication.
+
+The =kerberos.principal= indicates the Kerberos principal to be used for HTTP endpoint.
+The principal MUST start with 'HTTP/' as per Kerberos HTTP SPNEGO specification.
+
+The =kerberos.keytab= indicates the location of the keytab file with the credentials for the principal.
+It should be the same keytab file Oozie uses for its Kerberos credentials for Hadoop.
+
+---+++ Oozie Hadoop Authentication Configuration
 
 Oozie can work with Hadoop 20 with Security distribution which supports Kerberos authentication.
 
-Oozie authentication is configured using the following configuration properties (default values shown):
+Oozie Hadoop authentication is configured using the following configuration properties (default values shown):
 
 <verbatim>
   oozie.service.HadoopAccessorService.kerberos.enabled=false

--- a/docs/src/site/twiki/AG_Install.twiki
+++ b/docs/src/site/twiki/AG_Install.twiki
@@ -185,6 +185,7 @@ Oozie user authentication is configured using the following configuration proper
   oozie.authentication.type=simple
   oozie.authentication.token.validity=36000
   oozie.authentication.signature.secret=
+  oozie.authentication.cookie.domain=
   oozie.authentication.simple.anonymous.allowed=true
   oozie.authentication.kerberos.principal=HTTP/localhost@${local.realm}
   oozie.authentication.kerberos.keytab=${oozie.service.HadoopAccessorService.keytab.file}
@@ -198,6 +199,10 @@ to be renewed.
 
 The =signature.secret= is the signature secret for signing the authentication tokens. If not set a random
 secret is generated at startup time.
+
+The =oozie.authentication.cookie.domain= The domain to use for the HTTP cookie that stores the
+authentication token. In order to authentiation to work correctly across all Hadoop nodes web-consoles
+the domain must be correctly set.
 
 The =simple.anonymous.allowed= indicates if anonymous requests are allowed. This setting is meaningful
 only when using 'simple' authentication.

--- a/docs/src/site/twiki/DG_CommandLineTool.twiki
+++ b/docs/src/site/twiki/DG_CommandLineTool.twiki
@@ -19,11 +19,14 @@ The =oozie= CLI interacts with Oozie via its WS API.
 usage:
       the env variable 'OOZIE_URL' is used as default value for the '-oozie' option
       custom headers for Oozie web services can be specified using '-Dheader:NAME=VALUE'
-
+      '-Dskip.auth' disables authentication, it must be used when the Oozie server is version 2.3 or earlier
+      '-Dskip.auth.file' disables storing authentication in the '~/.oozie-auth-token' file
+      '-Dauthenticator.class=CLASS' is used to specify a custom authenticator implementation
+.
       oozie help : display usage
-
+.
       oozie version : show client version
-
+.
       oozie job <OPTIONS> : job operations
                 -action <arg>         coordinator rerun on action ids (requires -rerun)
                 -change <arg>         change a coordinator job
@@ -52,7 +55,7 @@ usage:
                 -value <arg>          new endtime/concurrency/pausetime value for changing a
                                       coordinator job
                 -verbose              verbose mode
-
+.
       oozie jobs <OPTIONS> : jobs status
                  -filter <arg>    user=<U>;name=<N>;group=<G>;status=<S>;...
                  -jobtype <arg>   job type ('Supported in Oozie-2.0 or later versions ONLY -
@@ -62,7 +65,7 @@ usage:
                  -offset <arg>    jobs offset (default '1')
                  -oozie <arg>     Oozie URL
                  -verbose         verbose mode
-
+.
       oozie admin <OPTIONS> : admin operations
                   -oozie <arg>        Oozie URL
                   -queuedump          show Oozie server queue elements
@@ -70,14 +73,14 @@ usage:
                   -systemmode <arg>   Supported in Oozie-2.0 or later versions ONLY. Change oozie
                                       system mode [NORMAL|NOWEBSERVICE|SAFEMODE]
                   -version            show Oozie server build version
-
+.
       oozie validate <ARGS> : validate a workflow XML file
-
+.
       oozie sla <OPTIONS> : sla operations (Supported in Oozie-2.0 or later)
                 -len <arg>      number of results (default '100')
                 -offset <arg>   start offset (default '0')
                 -oozie <arg>    Oozie URL
-
+.
       oozie pig <OPTIONS> -X <ARGS> : submit a pig job, everything after '-X' are pass-through parameters to pig
                 -config <arg>         job configuration file '.properties'
                 -D <property=value>   set/override value for given property
@@ -86,6 +89,31 @@ usage:
 </verbatim>
 
 ---++ Common CLI Options
+
+---+++ Authentication
+
+The =oozie= CLI automatically perform authentication i the Oozie server requests it. By default it supports both
+pseudo/simple authentication and Kerberos HTTP SPNEGO authentication.
+
+For psuedo/simple authentication the =oozie= CLI uses the user name of the current OS user.
+
+For Kerberos HTTP SPNEGO authentication the =oozie= CLI uses the default principal for the OS Kerberos cache
+(normally the principal that did =kinit=).
+
+Oozie uses [[http://www.github.com/cloudera/alfredo][Alfredo, Java HTTP SPENGO]] library for authentication.
+This library can be extended to support other authentication mechanisms.
+
+To disable authentication altogether the =-Dskip.auth= option must be used. This is required for the =oozie= CLI to
+work with older versions of Oozie server.
+
+Once authentication is performed successfully the received authentication token is stored in the user home directory
+as =.oozie-auth-token= owner-read-only file. Subsequent requests reuse that token while valid.
+
+The use of the =~/.oozie-auth-token= file can be disabled by invoking the =oozie= CLI with the =-Dskip.auth.file=
+option.
+
+To use an custom authentication mechanism, an Alfredo =Authenticator= implementation must be specified with the
+ =-Dauthenticator.class= = =CLASS= option.
 
 ---+++ Oozie URL
 
@@ -256,7 +284,6 @@ is not in =FAILED= or =KILLED= state.
 After the command is executed the rerun coordiator action will be in =WAITING= status.
 
 Refer to the [[DG_CoordinatorRerun][Rerunning Coordinator Actions]] for details on rerun.
-
 
 ---+++ Checking the Status of a Workflow Job or Coordinator Job or Coordinator Action
 

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
             <dependency>
                 <groupId>com.cloudera.alfredo</groupId>
                 <artifactId>alfredo</artifactId>
-                <version>0.1.2</version>
+                <version>0.1.3</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,13 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>cdh.releases</id>
+            <url>https://repository.cloudera.com/content/repositories/releases</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -220,7 +227,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.3</version>
+                <version>1.4</version>
             </dependency>
             
             <dependency>
@@ -425,7 +432,13 @@
                 <version>10.6.1.0</version>
                 <scope>compile</scope>
             </dependency>
-            
+
+            <dependency>
+                <groupId>com.cloudera.alfredo</groupId>
+                <artifactId>alfredo</artifactId>
+                <version>0.1.2</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+GH-0035 Oozie should support Kerberos authentication on its HTTP REST API
 GH-0307 check for oozie setup owner in setup/start/stop scripts should be optional
 GH-0295 subworkflow action fails if workflow URI is a directory
 GH-0302 the ...wf.ext.schemas property should allow spaces/enters between schema files

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -68,14 +68,6 @@
                     <artifactId>jsp-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging-api</artifactId>
                 </exclusion>

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -143,4 +143,64 @@
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
 
+    <filter>
+        <filter-name>authenticationfilter</filter-name>
+        <filter-class>org.apache.oozie.servlet.OozieAuthenticationFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/versions/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/v0/admin/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/v1/admin/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/v0/jobs</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/v1/jobs</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/v0/job/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/v1/job/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/index.html</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>*.js</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/ext-2.2/*</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>authenticationfilter</filter-name>
+        <url-pattern>/docs/*</url-pattern>
+    </filter-mapping>
+
 </web-app>


### PR DESCRIPTION
This patch uses Alfredo (http://www.github.com/cloudera/alfredo) which is an Apache License 
2.0 library that support client/server Kerberos HTTP SPNEGO authentication (as well as 
anonymous and psuedo/simple). In addition Alfredo support custom authentication mechanisms 
via a client interface and a server interface. 

With this Oozie supports 'anonymous' (default, mechanism prior to this patch), 
'pseudo/simple' authentication (mimicking Hadoop pseudo/simple) and 'kerberos'
(Kerberos HTTP SPNEGO).

The server side integration required adding a subclass of Alfredo AuthenticationFilter to 
Oozie webapp web.xml file, this sub-class reads the configuration from Oozie configuration. 
A minor modification to the JsonRestServlet class to fetch the user name directly from the 
request. As well as adding support for the HTTP verb OPTIONS (which is used by Alfredo to 
trigger perform the authentication).

The client side integration required modifying the OozieClient class to use  Alfredo 
AuthenticatedURL class to establish the connection with the Oozie server.

Oozie CLI was also modified to support caching of the authentication token, custom 
authentication mechanisms via a system property and disabling authentication altogether (to 
be able to work against a previous version of Oozie server).

Testcases were also modified to include the authentication filter.

Install/CLI/Developer documentation were also updated.
