### PR TITLE
[2.2.6] GH-0510 credentialsConf should be initialized without loading defaults

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
@@ -499,7 +499,7 @@ public class JavaActionExecutor extends ActionExecutor {
                     action, actionConf);
 
             // Adding if action need to set more credential tokens
-            JobConf credentialsConf = new JobConf();
+            JobConf credentialsConf = new JobConf(false);
             XConfiguration.copy(actionConf, credentialsConf);
             setCredentialTokens(credentialsConf, context, action, credentialsProperties);
 


### PR DESCRIPTION
GH-0510 credentialsConf should be initialized without loading defaults
