### PR TITLE
Gh 0529

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -83,7 +83,7 @@
                         <configuration>
                             <target>
                                 <mkdir dir="downloads" />
-                                <get src="http://www.apache.org/dist/tomcat/tomcat-6/v6.0.32/bin/apache-tomcat-6.0.32.tar.gz" dest="downloads/tomcat.tar.gz" verbose="true" skipexisting="true" />
+                                <get src="http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.32/bin/apache-tomcat-6.0.32.tar.gz" dest="downloads/tomcat.tar.gz" verbose="true" skipexisting="true" />
                                 <delete dir="target/tomcat" />
                                 <mkdir dir="target/tomcat" />
                                 <gunzip src="downloads/tomcat.tar.gz" dest="target/tomcat/tomcat.tar" />

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+GH-0529 Update Tomcat download URL
 GH-0528 Refactor CoordActionMaterializeXCommand and CoordJobMatLookupXCommand to TransitionXCommand
 GH-0542 Refactor CoordSuspendXCommand & CoordResumeXCommand to TransitionXCommand based
 GH-0543 Refactor CoordRerunXCommand to TransitionXCommand based


### PR DESCRIPTION
The fix done for CDH-532 will break as soon as Tomcat releases a new version.

The correct fix is to get the Tomcat version from archive.apache.org
