### PR TITLE
[3.0] GH-0554 surefire plugin update to 2.7 to avoid outofmemory error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>2.7</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://jira.codehaus.org/browse/SUREFIRE-495

From this issue, 2.6 has memory leak problem. Oozie should use 2.7 instead.
