### PR TITLE
[Oozie 3.0] Gh 0569 Bundle status stays RUNNING when rerun a non-existing coord job

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/RerunTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/RerunTransitionXCommand.java
@@ -16,6 +16,7 @@ import org.apache.oozie.util.XLog;
 public abstract class RerunTransitionXCommand<T> extends TransitionXCommand<T> {
     protected String jobId;
     protected T ret;
+    protected Job.Status prevStatus;
 
     /**
      * The constructor for abstract class {@link RerunTransitionXCommand}
@@ -48,6 +49,7 @@ public abstract class RerunTransitionXCommand<T> extends TransitionXCommand<T> {
         if (job == null) {
             job = this.getJob();
         }
+        prevStatus = job.getStatus();
         job.setStatus(Job.Status.RUNNING);
         job.setPending();
     }

--- a/core/src/main/java/org/apache/oozie/command/RerunTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/RerunTransitionXCommand.java
@@ -113,4 +113,17 @@ public abstract class RerunTransitionXCommand<T> extends TransitionXCommand<T> {
     public XLog getLog() {
         return null;
     }
+
+    /**
+     * This method will return the previous status.
+     *
+     * @return JOB Status
+     */
+    public Job.Status getPrevStatus() {
+        if(prevStatus != null){
+            return prevStatus;
+        }else{
+            return job.getStatus();
+        }
+    }
 }

--- a/core/src/main/java/org/apache/oozie/command/bundle/BundleRerunXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/bundle/BundleRerunXCommand.java
@@ -41,6 +41,7 @@ public class BundleRerunXCommand extends RerunTransitionXCommand<Void> {
     private final boolean noCleanup;
     private BundleJobBean bundleJob;
     private List<BundleActionBean> bundleActions;
+    protected boolean prevPending;
 
     private JPAService jpaService = null;
 
@@ -75,6 +76,7 @@ public class BundleRerunXCommand extends RerunTransitionXCommand<Void> {
                 this.bundleActions = jpaService.execute(new BundleActionsGetJPAExecutor(jobId));
                 LogUtils.setLogInfo(bundleJob, logInfo);
                 super.setJob(bundleJob);
+                prevPending = bundleJob.isPending();
             }
             else {
                 throw new CommandException(ErrorCode.E0610);
@@ -142,9 +144,14 @@ public class BundleRerunXCommand extends RerunTransitionXCommand<Void> {
         LOG.info("Rerun coord jobs for the bundle=[{0}]", jobId);
     }
 
-    public final void transitToPrevious() throws CommandException {
-        bundleJob.setStatus(prevStatus);
-        bundleJob.resetPending();
+    private final void transitToPrevious() throws CommandException {
+        bundleJob.setStatus(getPrevStatus());
+        if(!prevPending){
+            bundleJob.resetPending();
+        }
+        else{
+            bundleJob.setPending();
+        }
         updateJob();
     }
 

--- a/core/src/main/java/org/apache/oozie/command/bundle/BundleRerunXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/bundle/BundleRerunXCommand.java
@@ -5,6 +5,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.oozie.BundleActionBean;
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.ErrorCode;
+import org.apache.oozie.XException;
 import org.apache.oozie.client.Job;
 import org.apache.oozie.client.rest.RestConstants;
 import org.apache.oozie.command.CommandException;
@@ -20,10 +24,6 @@ import org.apache.oozie.service.Services;
 import org.apache.oozie.util.LogUtils;
 import org.apache.oozie.util.ParamChecker;
 import org.apache.oozie.util.XLog;
-import org.apache.oozie.BundleActionBean;
-import org.apache.oozie.BundleJobBean;
-import org.apache.oozie.ErrorCode;
-import org.apache.oozie.XException;
 
 /**
  * Rerun bundle coordinator jobs by a list of coordinator names or dates. User can specify if refresh or noCleanup.
@@ -35,10 +35,10 @@ import org.apache.oozie.XException;
 public class BundleRerunXCommand extends RerunTransitionXCommand<Void> {
 
     protected final XLog LOG = XLog.getLog(BundleRerunXCommand.class);
-    private String coordScope;
-    private String dateScope;
-    private boolean refresh;
-    private boolean noCleanup;
+    private final String coordScope;
+    private final String dateScope;
+    private final boolean refresh;
+    private final boolean noCleanup;
     private BundleJobBean bundleJob;
     private List<BundleActionBean> bundleActions;
 
@@ -91,6 +91,7 @@ public class BundleRerunXCommand extends RerunTransitionXCommand<Void> {
      */
     @Override
     public void rerunChildren() throws CommandException {
+        boolean isUpdateActionDone = false;
         Map<String, BundleActionBean> coordNameToBAMapping = new HashMap<String, BundleActionBean>();
         if (bundleActions != null) {
             for (BundleActionBean action : bundleActions) {
@@ -113,6 +114,7 @@ public class BundleRerunXCommand extends RerunTransitionXCommand<Void> {
                     LOG.debug("Queuing rerun for coord id " + id + " of bundle " + bundleJob.getId());
                     queue(new CoordRerunXCommand(id, RestConstants.JOB_COORD_RERUN_DATE, dateScope, refresh, noCleanup));
                     updateBundleAction(coordNameToBAMapping.get(s));
+                    isUpdateActionDone = true;
                 }
                 else {
                     LOG.info("Rerun for coord " + s + " NOT performed because it is not in bundle ", bundleJob.getId());
@@ -130,11 +132,20 @@ public class BundleRerunXCommand extends RerunTransitionXCommand<Void> {
                     LOG.debug("Queuing rerun for coord id :" + action.getCoordId());
                     queue(new CoordRerunXCommand(action.getCoordId(), RestConstants.JOB_COORD_RERUN_DATE, dateScope, refresh, noCleanup));
                     updateBundleAction(action);
+                    isUpdateActionDone = true;
                 }
             }
         }
-
+        if(!isUpdateActionDone){
+            transitToPrevious();
+        }
         LOG.info("Rerun coord jobs for the bundle=[{0}]", jobId);
+    }
+
+    public final void transitToPrevious() throws CommandException {
+        bundleJob.setStatus(prevStatus);
+        bundleJob.resetPending();
+        updateJob();
     }
 
     /**

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+GH-0569 Bundle status stays RUNNING when rerun a non-existing coord job
 GH-0500 TestRerun should not use SSH action
 GH-0483 tests using pig 0.8 fails if a hadoop-site.xml or core-site.xml file is not in the classpath
 GH-0479 Add time ratio property to XTestCase waitFor


### PR DESCRIPTION
 Bundle status stays RUNNING when rerun a non-existing coord job
