### PR TITLE
[3.0] GH-0586 Fix bundle status transit and coordinator status transit

### DIFF
--- a/client/src/main/java/org/apache/oozie/client/CoordinatorAction.java
+++ b/client/src/main/java/org/apache/oozie/client/CoordinatorAction.java
@@ -14,7 +14,6 @@
  */
 package org.apache.oozie.client;
 
-import java.util.List;
 import java.util.Date;
 
 /**
@@ -30,6 +29,7 @@ public interface CoordinatorAction {
         READY,
         SUBMITTED,
         RUNNING,
+        SUSPENDED,
         TIMEDOUT,
         SUCCEEDED,
         KILLED,

--- a/core/src/main/java/org/apache/oozie/BundleActionBean.java
+++ b/core/src/main/java/org/apache/oozie/BundleActionBean.java
@@ -58,6 +58,8 @@ import org.apache.openjpa.persistence.jdbc.Index;
 
         @NamedQuery(name = "GET_BUNDLE_ACTIONS_NOT_EQUAL_STATUS_COUNT", query = "select count(w) from BundleActionBean w where w.bundleId = :bundleId AND w.status <> :status"),
 
+        @NamedQuery(name = "GET_BUNDLE_ACTIONS_NOT_TERMINATE_STATUS_COUNT", query = "select count(w) from BundleActionBean w where w.bundleId = :bundleId AND (w.status = 'PERP' OR w.status = 'RUNNING' OR w.status = 'SUSPENDED' OR w.status = 'PREPSUSPENDED' OR w.status = 'PAUSED' OR w.status = 'PREPPAUSED')"),
+
         @NamedQuery(name = "GET_BUNDLE_ACTIONS_FAILED_NULL_COORD_COUNT", query = "select count(w) from BundleActionBean w where w.bundleId = :bundleId AND w.status = 'FAILED' AND w.coordId IS NULL"),
 
         @NamedQuery(name = "GET_BUNDLE_ACTIONS_OLDER_THAN", query = "select OBJECT(w) from BundleActionBean w order by w.lastModifiedTimestamp"),

--- a/core/src/main/java/org/apache/oozie/BundleActionBean.java
+++ b/core/src/main/java/org/apache/oozie/BundleActionBean.java
@@ -60,7 +60,9 @@ import org.apache.openjpa.persistence.jdbc.Index;
 
         @NamedQuery(name = "GET_BUNDLE_ACTIONS_FAILED_NULL_COORD_COUNT", query = "select count(w) from BundleActionBean w where w.bundleId = :bundleId AND w.status = 'FAILED' AND w.coordId IS NULL"),
 
-        @NamedQuery(name = "GET_BUNDLE_ACTIONS_OLDER_THAN", query = "select OBJECT(w) from BundleActionBean w order by w.lastModifiedTimestamp") })
+        @NamedQuery(name = "GET_BUNDLE_ACTIONS_OLDER_THAN", query = "select OBJECT(w) from BundleActionBean w order by w.lastModifiedTimestamp"),
+
+        @NamedQuery(name = "DELETE_COMPLETED_ACTIONS_FOR_BUNDLE", query = "delete from BundleActionBean a where a.bundleId = :bundleId and (a.status = 'SUCCEEDED' OR a.status = 'FAILED' OR a.status= 'KILLED' OR a.status = 'DONEWITHERROR')")})
 public class BundleActionBean implements Writable {
 
     @Id

--- a/core/src/main/java/org/apache/oozie/BundleJobBean.java
+++ b/core/src/main/java/org/apache/oozie/BundleJobBean.java
@@ -63,7 +63,9 @@ import org.apache.openjpa.persistence.jdbc.Index;
 
         @NamedQuery(name = "GET_BUNDLE_JOBS_OLDER_THAN", query = "select OBJECT(w) from BundleJobBean w where w.startTimestamp <= :matTime AND (w.status = 'PREP' OR w.status = 'RUNNING')  order by w.lastModifiedTimestamp"),
 
-        @NamedQuery(name = "GET_BUNDLE_JOBS_OLDER_THAN_STATUS", query = "select OBJECT(w) from BundleJobBean w where w.status = :status AND w.lastModifiedTimestamp <= :lastModTime order by w.lastModifiedTimestamp") })
+        @NamedQuery(name = "GET_BUNDLE_JOBS_OLDER_THAN_STATUS", query = "select OBJECT(w) from BundleJobBean w where w.status = :status AND w.lastModifiedTimestamp <= :lastModTime order by w.lastModifiedTimestamp"),
+
+        @NamedQuery(name = "GET_COMPLETED_BUNDLE_JOBS_OLDER_THAN", query = "select OBJECT(w) from BundleJobBean w where ( w.status = 'SUCCEEDED' OR w.status = 'FAILED' OR w.status = 'KILLED' OR w.status = 'DONEWITHERROR') AND w.lastModifiedTimestamp <= :lastModTime order by w.lastModifiedTimestamp")})
 public class BundleJobBean extends JsonBundleJob implements Writable {
 
     @Basic

--- a/core/src/main/java/org/apache/oozie/CoordinatorActionBean.java
+++ b/core/src/main/java/org/apache/oozie/CoordinatorActionBean.java
@@ -70,7 +70,7 @@ import org.apache.openjpa.persistence.jdbc.Index;
 
     @NamedQuery(name = "GET_COORD_ACTIVE_ACTIONS_COUNT_BY_JOBID", query = "select count(a) from CoordinatorActionBean a where a.jobId = :jobId AND a.status = 'WAITING'"),
 
-    @NamedQuery(name = "GET_COORD_ACTIONS_PENDING_FALSE_COUNT", query = "select count(a) from CoordinatorActionBean a where a.jobId = :jobId AND a.pending = 0"),
+    @NamedQuery(name = "GET_COORD_ACTIONS_PENDING_FALSE_COUNT", query = "select count(a) from CoordinatorActionBean a where a.jobId = :jobId AND a.pending = 0 AND (a.status = 'SUSPENDED' OR a.status = 'TIMEDOUT' OR a.status = 'SUCCEEDED' OR a.status = 'KILLED' OR a.status = 'FAILED')"),
 
     @NamedQuery(name = "GET_COORD_ACTIONS_PENDING_FALSE_STATUS_COUNT", query = "select count(a) from CoordinatorActionBean a where a.jobId = :jobId AND a.pending = 0 AND a.status = :status"),
 

--- a/core/src/main/java/org/apache/oozie/command/KillTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/KillTransitionXCommand.java
@@ -44,10 +44,14 @@ public abstract class KillTransitionXCommand extends TransitionXCommand<Void> {
      */
     @Override
     protected Void execute() throws CommandException {
-        transitToNext();
-        updateJob();
-        killChildren();
-        notifyParent();
+        try {
+            transitToNext();
+            updateJob();
+            killChildren();
+        }
+        finally {
+            notifyParent();
+        }
         return null;
     }
 }

--- a/core/src/main/java/org/apache/oozie/command/RerunTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/RerunTransitionXCommand.java
@@ -67,10 +67,14 @@ public abstract class RerunTransitionXCommand<T> extends TransitionXCommand<T> {
     @Override
     protected T execute() throws CommandException {
         getLog().info("STARTED " + getClass().getSimpleName() + " for jobId=" + jobId);
-        transitToNext();
-        updateJob();
-        rerunChildren();
-        notifyParent();
+        try {
+            transitToNext();
+            updateJob();
+            rerunChildren();
+        }
+        finally {
+            notifyParent();
+        }
         getLog().info("ENDED " + getClass().getSimpleName() + " for jobId=" + jobId);
         return ret;
     }

--- a/core/src/main/java/org/apache/oozie/command/SubmitTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/SubmitTransitionXCommand.java
@@ -73,9 +73,13 @@ public abstract class SubmitTransitionXCommand extends TransitionXCommand<String
      */
     @Override
     protected String execute() throws CommandException {
-        transitToNext();
-        String jobId = submit();
-        notifyParent();
-        return jobId;
+        try {
+            transitToNext();
+            String jobId = submit();
+            return jobId;
+        }
+        finally {
+            notifyParent();
+        }
     }
 }

--- a/core/src/main/java/org/apache/oozie/command/bundle/BundleKillXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/bundle/BundleKillXCommand.java
@@ -105,8 +105,15 @@ public class BundleKillXCommand extends KillTransitionXCommand {
             for (BundleActionBean action : bundleActions) {
                 if (action.getCoordId() != null) {
                     queue(new CoordKillXCommand(action.getCoordId()));
+                    updateBundleAction(action);
+                    LOG.debug("Killed bundle action = [{0}], new status = [{1}], pending = [{2}] and queue CoordKillXCommand for [{3}]",
+                            action.getBundleActionId(), action.getStatus(), action.getPending(), action.getCoordId());
+                } else {
+                    updateBundleAction(action);
+                    LOG.debug("Killed bundle action = [{0}], current status = [{1}], pending = [{2}]", action.getBundleActionId(), action
+                            .getStatus(), action.getPending());
                 }
-                updateBundleAction(action);
+
             }
         }
         LOG.debug("Killed coord jobs for the bundle=[{0}]", jobId);
@@ -121,6 +128,7 @@ public class BundleKillXCommand extends KillTransitionXCommand {
     private void updateBundleAction(BundleActionBean action) throws CommandException {
         action.incrementAndGetPending();
         action.setLastModifiedTime(new Date());
+        action.setStatus(Job.Status.KILLED);
         try {
             jpaService.execute(new BundleActionUpdateJPAExecutor(action));
         }

--- a/core/src/main/java/org/apache/oozie/command/bundle/BundlePurgeXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/bundle/BundlePurgeXCommand.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.command.bundle;
+
+import java.util.List;
+
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.ErrorCode;
+import org.apache.oozie.XException;
+import org.apache.oozie.command.CommandException;
+import org.apache.oozie.command.PreconditionException;
+import org.apache.oozie.command.XCommand;
+import org.apache.oozie.executor.jpa.BundleActionsDeleteForPurgeJPAExecutor;
+import org.apache.oozie.executor.jpa.BundleJobDeleteJPAExecutor;
+import org.apache.oozie.executor.jpa.BundleJobsGetForPurgeJPAExecutor;
+import org.apache.oozie.executor.jpa.JPAExecutorException;
+import org.apache.oozie.service.JPAService;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.util.XLog;
+
+/**
+ * This class is used for bundle purge command
+ */
+public class BundlePurgeXCommand extends XCommand<Void> {
+    private static XLog LOG = XLog.getLog(BundlePurgeXCommand.class);
+    private JPAService jpaService = null;
+    private final int olderThan;
+    private final int limit;
+    private List<BundleJobBean> jobList = null;
+
+    public BundlePurgeXCommand(int olderThan, int limit) {
+        super("bundle_purge", "bundle_purge", 0);
+        this.olderThan = olderThan;
+        this.limit = limit;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.command.XCommand#loadState()
+     */
+    @Override
+    protected void loadState() throws CommandException {
+        try {
+            jpaService = Services.get().get(JPAService.class);
+
+            if (jpaService != null) {
+                this.jobList = jpaService.execute(new BundleJobsGetForPurgeJPAExecutor(olderThan, limit));
+            }
+            else {
+                throw new CommandException(ErrorCode.E0610);
+            }
+        }
+        catch (XException ex) {
+            throw new CommandException(ex);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.command.XCommand#execute()
+     */
+    @Override
+    protected Void execute() throws CommandException {
+        LOG.debug("STARTED Bundle-Purge to purge Jobs older than [{0}] days.", olderThan);
+
+        int actionDeleted = 0;
+        if (jobList != null && jobList.size() != 0) {
+            for (BundleJobBean bundle : jobList) {
+                String jobId = bundle.getId();
+                try {
+                    jpaService.execute(new BundleJobDeleteJPAExecutor(jobId));
+                    actionDeleted += jpaService.execute(new BundleActionsDeleteForPurgeJPAExecutor(jobId));
+                }
+                catch (JPAExecutorException e) {
+                    throw new CommandException(e);
+                }
+            }
+            LOG.debug("ENDED Bundle-Purge deleted jobs :" + jobList.size() + " and actions " + actionDeleted);
+        }
+        else {
+            LOG.debug("ENDED Bundle-Purge no Bundle job to be deleted");
+        }
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.command.XCommand#getEntityKey()
+     */
+    @Override
+    protected String getEntityKey() {
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.command.XCommand#isLockRequired()
+     */
+    @Override
+    protected boolean isLockRequired() {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.command.XCommand#verifyPrecondition()
+     */
+    @Override
+    protected void verifyPrecondition() throws CommandException, PreconditionException {
+    }
+}

--- a/core/src/main/java/org/apache/oozie/command/coord/CoordActionReadyXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordActionReadyXCommand.java
@@ -20,7 +20,9 @@ import org.apache.oozie.CoordinatorActionBean;
 import org.apache.oozie.CoordinatorJobBean;
 import org.apache.oozie.ErrorCode;
 import org.apache.oozie.client.CoordinatorAction;
+import org.apache.oozie.client.Job;
 import org.apache.oozie.command.CommandException;
+import org.apache.oozie.command.PreconditionException;
 import org.apache.oozie.executor.jpa.CoordJobGetReadyActionsJPAExecutor;
 import org.apache.oozie.executor.jpa.CoordJobGetRunningActionsCountJPAExecutor;
 import org.apache.oozie.executor.jpa.JPAExecutorException;
@@ -137,7 +139,6 @@ public class CoordActionReadyXCommand extends CoordinatorXCommand<Void> {
         if (jpaService == null) {
             throw new CommandException(ErrorCode.E0610);
         }
-
         try {
             coordJob = jpaService.execute(new org.apache.oozie.executor.jpa.CoordJobGetJPAExecutor(jobId));
         }
@@ -148,7 +149,11 @@ public class CoordActionReadyXCommand extends CoordinatorXCommand<Void> {
     }
 
     @Override
-    protected void verifyPrecondition() throws CommandException {
-
+    protected void verifyPrecondition() throws CommandException, PreconditionException {
+        if (coordJob.getStatus() != Job.Status.RUNNING) {
+            throw new PreconditionException(ErrorCode.E1100, "[" + jobId
+                    + "]::CoordActionReady:: Ignoring job. Coordinator job is not in RUNNING state, but state="
+                    + coordJob.getStatus());
+        }
     }
 }

--- a/core/src/main/java/org/apache/oozie/command/coord/CoordActionUpdateXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordActionUpdateXCommand.java
@@ -155,6 +155,9 @@ public class CoordActionUpdateXCommand extends CoordinatorXCommand<Void> {
         if (workflow.getStatus() == WorkflowJob.Status.RUNNING || workflow.getStatus() == WorkflowJob.Status.SUSPENDED) {
             // update lastModifiedTime
             coordAction.setLastModifiedTime(new Date());
+            if (workflow.getStatus() == WorkflowJob.Status.SUSPENDED) {
+                coordAction.decrementAndGetPending();
+            }
             try {
                 jpaService.execute(new org.apache.oozie.executor.jpa.CoordActionUpdateJPAExecutor(coordAction));
             }

--- a/core/src/main/java/org/apache/oozie/command/coord/CoordKillXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordKillXCommand.java
@@ -112,7 +112,13 @@ public class CoordKillXCommand extends KillTransitionXCommand {
                         if (action.getExternalId() != null) {
                             queue(new KillXCommand(action.getExternalId()));
                             updateCoordAction(action);
-                            LOG.debug("Killed coord action = [{0}]", action.getId());
+                            LOG.debug("Killed coord action = [{0}], new status = [{1}], pending = [{2}] and queue KillXCommand for [{3}]",
+                                            action.getId(), action.getStatus(), action.getPending(), action.getExternalId());
+                        }
+                        else {
+                            updateCoordAction(action);
+                            LOG.debug("Killed coord action = [{0}], current status = [{1}], pending = [{2}]", action.getId(), action
+                                    .getStatus(), action.getPending());
                         }
                     }
                 }
@@ -124,17 +130,15 @@ public class CoordKillXCommand extends KillTransitionXCommand {
         catch (JPAExecutorException ex) {
             throw new CommandException(ex);
         }
-        finally {
-            // update bundle action
-            if (coordJob.getBundleId() != null) {
-                BundleStatusUpdateXCommand bundleStatusUpdate = new BundleStatusUpdateXCommand(coordJob, prevStatus);
-                bundleStatusUpdate.call();
-            }
-        }
     }
 
     @Override
     public void notifyParent() throws CommandException {
+        // update bundle action
+        if (coordJob.getBundleId() != null) {
+            BundleStatusUpdateXCommand bundleStatusUpdate = new BundleStatusUpdateXCommand(coordJob, prevStatus);
+            bundleStatusUpdate.call();
+        }
     }
 
     @Override

--- a/core/src/main/java/org/apache/oozie/command/coord/CoordMaterializeTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordMaterializeTransitionXCommand.java
@@ -252,7 +252,7 @@ public class CoordMaterializeTransitionXCommand extends MaterializeTransitionXCo
         cron.start();
         try {
             materializeActions(false);
-            updateJobTable(coordJob);
+            updateJobMaterializeInfo(coordJob);
         }
         catch (CommandException ex) {
             LOG.warn("Exception occurs:" + ex.getMessage() + " Making the job failed ", ex);
@@ -389,7 +389,7 @@ public class CoordMaterializeTransitionXCommand extends MaterializeTransitionXCo
                 .getUser(), coordJob.getGroup(), LOG);
     }
 
-    private void updateJobTable(CoordinatorJobBean job) throws CommandException {
+    private void updateJobMaterializeInfo(CoordinatorJobBean job) throws CommandException {
         job.setLastActionTime(endMatdTime);
         job.setLastActionNumber(lastActionNumber);
         // if the job endtime == action endtime, we don't need to materialize this job anymore
@@ -406,12 +406,6 @@ public class CoordMaterializeTransitionXCommand extends MaterializeTransitionXCo
         }
 
         job.setNextMaterializedTime(endMatdTime);
-        try {
-            jpaService.execute(new CoordJobUpdateJPAExecutor(job));
-        }
-        catch (JPAExecutorException ex) {
-            throw new CommandException(ex);
-        }
     }
 
     /* (non-Javadoc)

--- a/core/src/main/java/org/apache/oozie/command/wf/ActionStartXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/ActionStartXCommand.java
@@ -246,7 +246,8 @@ public class ActionStartXCommand extends ActionXCommand<Void> {
                 case FAILED:
                     try {
                         failJob(context);
-                        queue(new CoordActionUpdateXCommand(wfJob));
+                        // update coordinator action
+                        new CoordActionUpdateXCommand(wfJob).call();
                         new WfEndXCommand(wfJob).call(); //To delete the WF temp dir
                         SLADbXOperations.writeStausEvent(wfAction.getSlaXml(), wfAction.getId(), Status.FAILED,
                                 SlaAppType.WORKFLOW_ACTION);
@@ -287,7 +288,8 @@ public class ActionStartXCommand extends ActionXCommand<Void> {
         }
         SLADbXOperations.writeStausEvent(action.getSlaXml(), action.getId(), Status.FAILED, SlaAppType.WORKFLOW_ACTION);
         SLADbXOperations.writeStausEvent(workflow.getSlaXml(), workflow.getId(), Status.FAILED, SlaAppType.WORKFLOW_JOB);
-        queue(new CoordActionUpdateXCommand(workflow));
+        // update coordinator action
+        new CoordActionUpdateXCommand(workflow).call();
         new WfEndXCommand(wfJob).call(); //To delete the WF temp dir
         return;
     }

--- a/core/src/main/java/org/apache/oozie/command/wf/KillXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/KillXCommand.java
@@ -151,8 +151,7 @@ public class KillXCommand extends WorkflowXCommand<Void> {
                  new WfEndXCommand(wfJob).call(); //To delete the WF temp dir
             }
             // update coordinator action
-            CoordActionUpdateXCommand coordActionUpdate = new CoordActionUpdateXCommand(wfJob);
-            coordActionUpdate.call();
+            new CoordActionUpdateXCommand(wfJob).call();
         }
 
         LOG.info("ENDED WorkflowKillXCommand for jobId=" + wfId);

--- a/core/src/main/java/org/apache/oozie/command/wf/SignalXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/SignalXCommand.java
@@ -267,7 +267,8 @@ public class SignalXCommand extends WorkflowXCommand<Void> {
         XLog.getLog(getClass()).debug(
                 "Updated the workflow status to " + wfJob.getId() + "  status =" + wfJob.getStatusStr());
         if (wfJob.getStatus() != WorkflowJob.Status.RUNNING && wfJob.getStatus() != WorkflowJob.Status.SUSPENDED) {
-            queue(new CoordActionUpdateXCommand(wfJob));
+            // update coordinator action
+            new CoordActionUpdateXCommand(wfJob).call();
             new WfEndXCommand(wfJob).call(); //To delete the WF temp dir
         }
         LOG.debug("ENDED SignalCommand for jobid=" + jobId + ", actionId=" + actionId);

--- a/core/src/main/java/org/apache/oozie/command/wf/SuspendXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/SuspendXCommand.java
@@ -22,6 +22,7 @@ import org.apache.oozie.WorkflowJobBean;
 import org.apache.oozie.client.WorkflowJob;
 import org.apache.oozie.command.CommandException;
 import org.apache.oozie.command.PreconditionException;
+import org.apache.oozie.command.coord.CoordActionUpdateXCommand;
 import org.apache.oozie.executor.jpa.JPAExecutorException;
 import org.apache.oozie.executor.jpa.WorkflowActionRetryManualGetJPAExecutor;
 import org.apache.oozie.executor.jpa.WorkflowActionUpdateJPAExecutor;
@@ -29,7 +30,6 @@ import org.apache.oozie.executor.jpa.WorkflowJobGetJPAExecutor;
 import org.apache.oozie.executor.jpa.WorkflowJobUpdateJPAExecutor;
 import org.apache.oozie.service.JPAService;
 import org.apache.oozie.service.Services;
-import org.apache.oozie.store.StoreException;
 import org.apache.oozie.util.InstrumentUtils;
 import org.apache.oozie.util.LogUtils;
 import org.apache.oozie.util.ParamChecker;
@@ -63,6 +63,10 @@ public class SuspendXCommand extends WorkflowXCommand<Void> {
         }
         catch (JPAExecutorException je) {
             throw new CommandException(je);
+        }
+        finally {
+            // update coordinator action
+            new CoordActionUpdateXCommand(wfJobBean).call();
         }
         return null;
     }

--- a/core/src/main/java/org/apache/oozie/executor/jpa/BundleActionsDeleteForPurgeJPAExecutor.java
+++ b/core/src/main/java/org/apache/oozie/executor/jpa/BundleActionsDeleteForPurgeJPAExecutor.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.executor.jpa;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.oozie.ErrorCode;
+import org.apache.oozie.util.ParamChecker;
+
+/**
+ * Delete the list of BundleAction for a BundleJob and return the number of actions been deleted.
+ */
+public class BundleActionsDeleteForPurgeJPAExecutor implements JPAExecutor<Integer> {
+
+    private String bundleId = null;
+
+    public BundleActionsDeleteForPurgeJPAExecutor(String bundleId) {
+        ParamChecker.notNull(bundleId, "bundleId");
+        this.bundleId = bundleId;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.executor.jpa.JPAExecutor#getName()
+     */
+    @Override
+    public String getName() {
+        return "BundleActionsDeleteForPurgeJPAExecutor";
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.executor.jpa.JPAExecutor#execute(javax.persistence.EntityManager)
+     */
+    @Override
+    public Integer execute(EntityManager em) throws JPAExecutorException {
+        int actionsDeleted = 0;
+        try {
+            Query g = em.createNamedQuery("DELETE_COMPLETED_ACTIONS_FOR_BUNDLE");
+            g.setParameter("bundleId", bundleId);
+            actionsDeleted = g.executeUpdate();
+        }
+        catch (Exception e) {
+            throw new JPAExecutorException(ErrorCode.E0603, e);
+        }
+        return actionsDeleted;
+    }
+}

--- a/core/src/main/java/org/apache/oozie/executor/jpa/BundleActionsNotTerminateStatusCountGetJPAExecutor.java
+++ b/core/src/main/java/org/apache/oozie/executor/jpa/BundleActionsNotTerminateStatusCountGetJPAExecutor.java
@@ -1,0 +1,40 @@
+package org.apache.oozie.executor.jpa;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.oozie.ErrorCode;
+import org.apache.oozie.util.ParamChecker;
+
+/**
+ * Load the number of actions for a bundle job which are not terminate status ('PERP' OR 'RUNNING' OR 'SUSPENDED' OR
+ * 'PREPSUSPENDED' OR 'PAUSED' OR 'PREPPAUSED').
+ */
+public class BundleActionsNotTerminateStatusCountGetJPAExecutor implements JPAExecutor<Integer> {
+
+    private String bundleJobId = null;
+
+    public BundleActionsNotTerminateStatusCountGetJPAExecutor(String bundleJobId) {
+        ParamChecker.notNull(bundleJobId, "bundleJobId");
+        this.bundleJobId = bundleJobId;
+    }
+
+    @Override
+    public String getName() {
+        return "BundleActionsNotTerminateStatusCountGetJPAExecutor";
+    }
+
+    @Override
+    public Integer execute(EntityManager em) throws JPAExecutorException {
+        try {
+            Query q = em.createNamedQuery("GET_BUNDLE_ACTIONS_NOT_TERMINATE_STATUS_COUNT");
+            q.setParameter("bundleId", bundleJobId);
+            Long count = (Long) q.getSingleResult();
+            return Integer.valueOf(count.intValue());
+        }
+        catch (Exception e) {
+            throw new JPAExecutorException(ErrorCode.E0603, e);
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/oozie/executor/jpa/BundleJobDeleteJPAExecutor.java
+++ b/core/src/main/java/org/apache/oozie/executor/jpa/BundleJobDeleteJPAExecutor.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.executor.jpa;
+
+import javax.persistence.EntityManager;
+
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.util.ParamChecker;
+
+/**
+ * Delete bundle job
+ */
+public class BundleJobDeleteJPAExecutor implements JPAExecutor<Void> {
+
+    private String bundleJobId = null;
+
+    public BundleJobDeleteJPAExecutor(String bundleJobId) {
+        ParamChecker.notEmpty(bundleJobId, "bundleJobId");
+        this.bundleJobId = bundleJobId;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.executor.jpa.JPAExecutor#execute(javax.persistence.EntityManager)
+     */
+    @Override
+    public Void execute(EntityManager em) throws JPAExecutorException {
+        BundleJobBean job = em.find(BundleJobBean.class, this.bundleJobId);
+        if (job != null) {
+            em.remove(job);
+        }
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.executor.jpa.JPAExecutor#getName()
+     */
+    @Override
+    public String getName() {
+        return "BundleJobDeleteJPAExecutor";
+    }
+}

--- a/core/src/main/java/org/apache/oozie/executor/jpa/BundleJobsGetForPurgeJPAExecutor.java
+++ b/core/src/main/java/org/apache/oozie/executor/jpa/BundleJobsGetForPurgeJPAExecutor.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.executor.jpa;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.ErrorCode;
+
+/**
+ * Load the list of completed BundleJob for purge ready.
+ */
+public class BundleJobsGetForPurgeJPAExecutor implements JPAExecutor<List<BundleJobBean>> {
+
+    private static final long DAY_IN_MS = 24 * 60 * 60 * 1000;
+    private long olderThanDays;
+    private int limit;
+
+    public BundleJobsGetForPurgeJPAExecutor(long olderThanDays, int limit) {
+        this.olderThanDays = olderThanDays;
+        this.limit = limit;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.executor.jpa.JPAExecutor#getName()
+     */
+    @Override
+    public String getName() {
+        return "BundleJobsGetForPurgeJPAExecutor";
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.executor.jpa.JPAExecutor#execute(javax.persistence.EntityManager)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<BundleJobBean> execute(EntityManager em) throws JPAExecutorException {
+        List<BundleJobBean> bundleJobs = null;
+        try {
+            Timestamp lastModTm = new Timestamp(System.currentTimeMillis() - (olderThanDays * DAY_IN_MS));
+            Query jobQ = em.createNamedQuery("GET_COMPLETED_BUNDLE_JOBS_OLDER_THAN");
+            jobQ.setParameter("lastModTime", lastModTm);
+            jobQ.setMaxResults(limit);
+            bundleJobs = jobQ.getResultList();
+        }
+        catch (Exception e) {
+            throw new JPAExecutorException(ErrorCode.E0603, e);
+        }
+        return bundleJobs;
+    }
+
+}

--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -155,7 +155,7 @@
         <name>oozie.service.PurgeService.older.than</name>
         <value>30</value>
         <description>
-            Jobs older than this value, in days, will be purged by the PurgeService.
+            Completed workflow jobs older than this value, in days, will be purged by the PurgeService.
         </description>
     </property>
     
@@ -163,12 +163,20 @@
         <name>oozie.service.PurgeService.coord.older.than</name>
         <value>7</value>
         <description>
-            Completed Actions older than this value, in days, will be purged by the PurgeService.
+            Completed coordinator jobs older than this value, in days, will be purged by the PurgeService.
         </description>
     </property>
-	
-	<property>
-		<name>oozie.service.PurgeService.coord.purge.limit</name>
+    
+    <property>
+        <name>oozie.service.PurgeService.bundle.older.than</name>
+        <value>7</value>
+        <description>
+            Completed bundle jobs older than this value, in days, will be purged by the PurgeService.
+        </description>
+    </property>
+    
+    <property>
+		<name>oozie.service.PurgeService.purge.limit</name>
 		<value>100</value>
 		<description>
 			Completed Actions purge - limit each purge to this value
@@ -182,7 +190,7 @@
             Interval at which the purge service will run, in seconds.
         </description>
     </property>
-
+    
     <!-- RecoveryService -->
 
     <property>

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundleChangeXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundleChangeXCommand.java
@@ -53,7 +53,7 @@ public class TestBundleChangeXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleChange1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         String dateStr = "2099-01-01T01:00Z";
 
         JPAService jpaService = Services.get().get(JPAService.class);
@@ -75,7 +75,7 @@ public class TestBundleChangeXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleChange2() throws Exception {
-        BundleJobBean bundleJob = this.addRecordToBundleJobTable(Job.Status.RUNNING);
+        BundleJobBean bundleJob = this.addRecordToBundleJobTable(Job.Status.RUNNING, false);
 
         CoordinatorJobBean coordJob = addRecordToCoordJobTable(CoordinatorJob.Status.SUCCEEDED, false);
         coordJob.setBundleId(bundleJob.getId());
@@ -117,7 +117,7 @@ public class TestBundleChangeXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleChangeNegative1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         String dateStr = "2099-01-01Ta1:00Z";
 
         JPAService jpaService = Services.get().get(JPAService.class);
@@ -141,7 +141,7 @@ public class TestBundleChangeXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleChangeNegative2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         String dateStr = "2009-01-01T01:00Z";
 
         JPAService jpaService = Services.get().get(JPAService.class);

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundleJobSuspendXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundleJobSuspendXCommand.java
@@ -59,7 +59,7 @@ public class TestBundleJobSuspendXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleSuspend1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -79,7 +79,7 @@ public class TestBundleJobSuspendXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleSuspend2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         final JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -157,7 +157,7 @@ public class TestBundleJobSuspendXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleSuspend3() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -193,7 +193,7 @@ public class TestBundleJobSuspendXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleSuspendFailed() throws Exception {
-        this.addRecordToBundleJobTable(Job.Status.PREP);
+        this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         try {
             new BundleJobSuspendXCommand("bundle-id").call();

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundleJobXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundleJobXCommand.java
@@ -46,7 +46,7 @@ public class TestBundleJobXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleJobInfo1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -67,7 +67,7 @@ public class TestBundleJobXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleJobInfoFailed() throws Exception {
-        this.addRecordToBundleJobTable(Job.Status.PREP);
+        this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         try {
             new BundleJobXCommand("bundle-id").call();

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundleJobsXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundleJobsXCommand.java
@@ -43,14 +43,14 @@ public class TestBundleJobsXCommand extends XDataTestCase {
     }
 
     public void testBundleJobsGet() throws Exception {
-        addRecordToBundleJobTable(Job.Status.PREP);
-        addRecordToBundleJobTable(Job.Status.PREP);
-        addRecordToBundleJobTable(Job.Status.RUNNING);
-        addRecordToBundleJobTable(Job.Status.RUNNING);
+        addRecordToBundleJobTable(Job.Status.PREP, false);
+        addRecordToBundleJobTable(Job.Status.PREP, false);
+        addRecordToBundleJobTable(Job.Status.RUNNING, false);
+        addRecordToBundleJobTable(Job.Status.RUNNING, false);
         _testGetJobsForStatus();
         _testGetJobsForGroup();
-        addRecordToBundleJobTable(Job.Status.KILLED);
-        addRecordToBundleJobTable(Job.Status.SUCCEEDED);
+        addRecordToBundleJobTable(Job.Status.KILLED, false);
+        addRecordToBundleJobTable(Job.Status.SUCCEEDED, false);
         _testGetJobsForAppName();
         _testGetJobInfoForUser();
         _testGetJobsForUserAndStatus();

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundleKillXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundleKillXCommand.java
@@ -59,7 +59,7 @@ public class TestBundleKillXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleKill1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -79,7 +79,7 @@ public class TestBundleKillXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleKill2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         final JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -159,7 +159,7 @@ public class TestBundleKillXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleKill3() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -195,7 +195,7 @@ public class TestBundleKillXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleKillFailed() throws Exception {
-        this.addRecordToBundleJobTable(Job.Status.PREP);
+        this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         try {
             new BundleKillXCommand("bundle-id").call();

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundlePauseUnpauseXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundlePauseUnpauseXCommand.java
@@ -44,7 +44,7 @@ public class TestBundlePauseUnpauseXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundlePauseUnpause1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -68,7 +68,7 @@ public class TestBundlePauseUnpauseXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundlePauseUnpause2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -92,7 +92,7 @@ public class TestBundlePauseUnpauseXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundlePauseUnpause3() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNINGWITHERROR);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNINGWITHERROR, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -116,7 +116,7 @@ public class TestBundlePauseUnpauseXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundlePauseUnpauseNeg1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUSPENDED);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUSPENDED, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundlePurgeXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundlePurgeXCommand.java
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.command.bundle;
+
+import java.util.Date;
+
+import org.apache.oozie.BundleActionBean;
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.client.Job;
+import org.apache.oozie.executor.jpa.BundleActionGetJPAExecutor;
+import org.apache.oozie.executor.jpa.BundleJobGetJPAExecutor;
+import org.apache.oozie.executor.jpa.BundleJobInsertJPAExecutor;
+import org.apache.oozie.executor.jpa.JPAExecutorException;
+import org.apache.oozie.service.JPAService;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.test.XDataTestCase;
+import org.apache.oozie.util.DateUtils;
+
+public class TestBundlePurgeXCommand extends XDataTestCase {
+    private Services services;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        services = new Services();
+        services.init();
+        cleanUpDBTables();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        services.destroy();
+        super.tearDown();
+    }
+
+    /**
+     * Test : purge succeeded bundle job and action successfully
+     *
+     * @throws Exception
+     */
+    public void testSucBundlePurgeXCommand() throws Exception {
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+        this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.SUCCEEDED);
+        this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.SUCCEEDED);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        BundleJobGetJPAExecutor bundleJobGetExecutor = new BundleJobGetJPAExecutor(job.getId());
+        job = jpaService.execute(bundleJobGetExecutor);
+        assertEquals(Job.Status.SUCCEEDED, job.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor1 = new BundleActionGetJPAExecutor(job.getId(), "action1");
+        BundleActionBean action1 = jpaService.execute(bundleActionGetExecutor1);
+        assertEquals(Job.Status.SUCCEEDED, action1.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor2 = new BundleActionGetJPAExecutor(job.getId(), "action2");
+        BundleActionBean action2 = jpaService.execute(bundleActionGetExecutor2);
+        assertEquals(Job.Status.SUCCEEDED, action2.getStatus());
+
+        new BundlePurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(bundleJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor1);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor2);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+    }
+
+    /**
+     * Test : purge failed bundle job and action successfully
+     *
+     * @throws Exception
+     */
+    public void testFailBundlePurgeXCommand() throws Exception {
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.DONEWITHERROR, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+        this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.FAILED);
+        this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.SUCCEEDED);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        BundleJobGetJPAExecutor bundleJobGetExecutor = new BundleJobGetJPAExecutor(job.getId());
+        job = jpaService.execute(bundleJobGetExecutor);
+        assertEquals(Job.Status.DONEWITHERROR, job.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor1 = new BundleActionGetJPAExecutor(job.getId(), "action1");
+        BundleActionBean action1 = jpaService.execute(bundleActionGetExecutor1);
+        assertEquals(Job.Status.FAILED, action1.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor2 = new BundleActionGetJPAExecutor(job.getId(), "action2");
+        BundleActionBean action2 = jpaService.execute(bundleActionGetExecutor2);
+        assertEquals(Job.Status.SUCCEEDED, action2.getStatus());
+
+        new BundlePurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(bundleJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor1);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor2);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+    }
+
+    /**
+     * Test : purge killed bundle job and action successfully
+     *
+     * @throws Exception
+     */
+    public void testKillBundlePurgeXCommand() throws Exception {
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.KILLED, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+        this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.KILLED);
+        this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.KILLED);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        BundleJobGetJPAExecutor bundleJobGetExecutor = new BundleJobGetJPAExecutor(job.getId());
+        job = jpaService.execute(bundleJobGetExecutor);
+        assertEquals(Job.Status.KILLED, job.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor1 = new BundleActionGetJPAExecutor(job.getId(), "action1");
+        BundleActionBean action1 = jpaService.execute(bundleActionGetExecutor1);
+        assertEquals(Job.Status.KILLED, action1.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor2 = new BundleActionGetJPAExecutor(job.getId(), "action2");
+        BundleActionBean action2 = jpaService.execute(bundleActionGetExecutor2);
+        assertEquals(Job.Status.KILLED, action2.getStatus());
+
+        new BundlePurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(bundleJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor1);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor2);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+    }
+
+    /**
+     * Test : purge bundle job and action failed
+     *
+     * @throws Exception
+     */
+    public void testBundlePurgeXCommandFailed() throws Exception {
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+        this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.RUNNING);
+        this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.SUCCEEDED);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        BundleJobGetJPAExecutor bundleJobGetExecutor = new BundleJobGetJPAExecutor(job.getId());
+        job = jpaService.execute(bundleJobGetExecutor);
+        assertEquals(Job.Status.RUNNING, job.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor1 = new BundleActionGetJPAExecutor(job.getId(), "action1");
+        BundleActionBean action1 = jpaService.execute(bundleActionGetExecutor1);
+        assertEquals(Job.Status.RUNNING, action1.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor2 = new BundleActionGetJPAExecutor(job.getId(), "action2");
+        BundleActionBean action2 = jpaService.execute(bundleActionGetExecutor2);
+        assertEquals(Job.Status.SUCCEEDED, action2.getStatus());
+
+        new BundlePurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(bundleJobGetExecutor);
+        }
+        catch (JPAExecutorException je) {
+            // Job should exist. Exception is not expected.
+            fail("Job should exist. If not, fail it.");
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor1);
+        }
+        catch (JPAExecutorException je) {
+            // Job should exist. Exception is not expected.
+            fail("Action should exist. If not, fail it.");
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor2);
+        }
+        catch (JPAExecutorException je) {
+            // Job should exist. Exception is not expected.
+            fail("Action should exist. If not, fail it.");
+        }
+    }
+
+    protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
+        BundleJobBean bundle = createBundleJob(jobStatus);
+        bundle.setLastModifiedTime(lastModifiedTime);
+        try {
+            JPAService jpaService = Services.get().get(JPAService.class);
+            assertNotNull(jpaService);
+            BundleJobInsertJPAExecutor bundleInsertjpa = new BundleJobInsertJPAExecutor(bundle);
+            jpaService.execute(bundleInsertjpa);
+        }
+        catch (JPAExecutorException je) {
+            je.printStackTrace();
+            fail("Unable to insert the test bundle job record to table");
+            throw je;
+        }
+        return bundle;
+    }
+}

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundlePurgeXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundlePurgeXCommand.java
@@ -253,7 +253,7 @@ public class TestBundlePurgeXCommand extends XDataTestCase {
     }
 
     protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
-        BundleJobBean bundle = createBundleJob(jobStatus);
+        BundleJobBean bundle = createBundleJob(jobStatus, false);
         bundle.setLastModifiedTime(lastModifiedTime);
         try {
             JPAService jpaService = Services.get().get(JPAService.class);

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundleRerunXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundleRerunXCommand.java
@@ -35,7 +35,7 @@ public class TestBundleRerunXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleRerun1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, false);
         this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.SUCCEEDED);
         this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.SUCCEEDED);
         addRecordToCoordJobTable("action1", CoordinatorJob.Status.SUCCEEDED, false);
@@ -59,7 +59,7 @@ public class TestBundleRerunXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleRerun2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, false);
         this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.SUCCEEDED);
         this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.SUCCEEDED);
         addRecordToCoordJobTable("action1", CoordinatorJob.Status.SUCCEEDED, false);

--- a/core/src/test/java/org/apache/oozie/command/bundle/TestBundleStartXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/bundle/TestBundleStartXCommand.java
@@ -57,7 +57,7 @@ public class TestBundleStartXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleStart1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -88,7 +88,7 @@ public class TestBundleStartXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleStart2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         final JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -146,7 +146,7 @@ public class TestBundleStartXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleStartDryrun() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
@@ -177,7 +177,7 @@ public class TestBundleStartXCommand extends XDataTestCase {
      * @throws Exception
      */
     public void testBundleStartNegative1() throws Exception {
-        this.addRecordToBundleJobTable(Job.Status.PREP);
+        this.addRecordToBundleJobTable(Job.Status.PREP, false);
 
         try {
             new BundleStartXCommand("bundle-id").call();
@@ -187,7 +187,7 @@ public class TestBundleStartXCommand extends XDataTestCase {
             // Job doesn't exist. Exception is expected.
         }
     }
-    
+
     /**
      * Test : Start bundle job that contains bad coordinator job
      *
@@ -207,10 +207,10 @@ public class TestBundleStartXCommand extends XDataTestCase {
         waitFor(120000, new Predicate() {
             public boolean evaluate() throws Exception {
                 BundleJobBean job1 = jpaService.execute(bundleJobGetExecutor);
-                return job1.getStatus().equals(Job.Status.KILLED);
+                return job1.getStatus().equals(Job.Status.DONEWITHERROR);
             }
         });
         job = jpaService.execute(bundleJobGetExecutor);
-        assertEquals(job.getStatus(), Job.Status.KILLED);
+        assertEquals(Job.Status.DONEWITHERROR, job.getStatus());
     }
 }

--- a/core/src/test/java/org/apache/oozie/command/coord/TestCoordPurgeXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/coord/TestCoordPurgeXCommand.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.command.coord;
+
+import org.apache.oozie.CoordinatorActionBean;
+import org.apache.oozie.CoordinatorJobBean;
+import org.apache.oozie.client.CoordinatorAction;
+import org.apache.oozie.client.CoordinatorJob;
+import org.apache.oozie.executor.jpa.CoordActionGetJPAExecutor;
+import org.apache.oozie.executor.jpa.CoordJobGetJPAExecutor;
+import org.apache.oozie.executor.jpa.CoordJobInsertJPAExecutor;
+import org.apache.oozie.executor.jpa.JPAExecutorException;
+import org.apache.oozie.service.JPAService;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.test.XDataTestCase;
+import org.apache.oozie.util.DateUtils;
+
+public class TestCoordPurgeXCommand extends XDataTestCase {
+    private Services services;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        services = new Services();
+        services.init();
+        cleanUpDBTables();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        services.destroy();
+        super.tearDown();
+    }
+
+    /**
+     * Test : purge succeeded coord job and action successfully
+     *
+     * @throws Exception
+     */
+    public void testSucCoordPurgeXCommand() throws Exception {
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.SUCCEEDED, false);
+        CoordinatorActionBean action = addRecordToCoordActionTable(job.getId(), 1, CoordinatorAction.Status.SUCCEEDED,
+                "coord-action-get.xml");
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        CoordJobGetJPAExecutor coordJobGetExecutor = new CoordJobGetJPAExecutor(job.getId());
+        CoordActionGetJPAExecutor coordActionGetExecutor = new CoordActionGetJPAExecutor(action.getId());
+
+        job = jpaService.execute(coordJobGetExecutor);
+        action = jpaService.execute(coordActionGetExecutor);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.SUCCEEDED);
+        assertEquals(action.getStatus(), CoordinatorAction.Status.SUCCEEDED);
+
+        new CoordPurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(coordJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(coordActionGetExecutor);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+    }
+
+    /**
+     * Test : purge failed coord job and action successfully
+     *
+     * @throws Exception
+     */
+    public void testFailCoordPurgeXCommand() throws Exception {
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.FAILED, false);
+        CoordinatorActionBean action = addRecordToCoordActionTable(job.getId(), 1, CoordinatorAction.Status.FAILED,
+                "coord-action-get.xml");
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        CoordJobGetJPAExecutor coordJobGetExecutor = new CoordJobGetJPAExecutor(job.getId());
+        CoordActionGetJPAExecutor coordActionGetExecutor = new CoordActionGetJPAExecutor(action.getId());
+
+        job = jpaService.execute(coordJobGetExecutor);
+        action = jpaService.execute(coordActionGetExecutor);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.FAILED);
+        assertEquals(action.getStatus(), CoordinatorAction.Status.FAILED);
+
+        new CoordPurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(coordJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(coordActionGetExecutor);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+    }
+
+    /**
+     * Test : purge killed coord job and action successfully
+     *
+     * @throws Exception
+     */
+    public void testKillCoordPurgeXCommand() throws Exception {
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.KILLED, false);
+        CoordinatorActionBean action = addRecordToCoordActionTable(job.getId(), 1, CoordinatorAction.Status.KILLED,
+                "coord-action-get.xml");
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        CoordJobGetJPAExecutor coordJobGetExecutor = new CoordJobGetJPAExecutor(job.getId());
+        CoordActionGetJPAExecutor coordActionGetExecutor = new CoordActionGetJPAExecutor(action.getId());
+
+        job = jpaService.execute(coordJobGetExecutor);
+        action = jpaService.execute(coordActionGetExecutor);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.KILLED);
+        assertEquals(action.getStatus(), CoordinatorAction.Status.KILLED);
+
+        new CoordPurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(coordJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(coordActionGetExecutor);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+    }
+
+    /**
+     * Test : purge coord job and action failed
+     *
+     * @throws Exception
+     */
+    public void testCoordPurgeXCommandFailed() throws Exception {
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.RUNNING, false);
+        CoordinatorActionBean action = addRecordToCoordActionTable(job.getId(), 1, CoordinatorAction.Status.SUCCEEDED,
+                "coord-action-get.xml");
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        CoordJobGetJPAExecutor coordJobGetExecutor = new CoordJobGetJPAExecutor(job.getId());
+        CoordActionGetJPAExecutor coordActionGetExecutor = new CoordActionGetJPAExecutor(action.getId());
+
+        job = jpaService.execute(coordJobGetExecutor);
+        action = jpaService.execute(coordActionGetExecutor);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.RUNNING);
+        assertEquals(action.getStatus(), CoordinatorAction.Status.SUCCEEDED);
+
+        new CoordPurgeXCommand(7, 10).call();
+
+        try {
+            job = jpaService.execute(coordJobGetExecutor);
+        }
+        catch (JPAExecutorException je) {
+            fail("Job should not be purged. Should fail.");
+        }
+
+        try {
+            jpaService.execute(coordActionGetExecutor);
+        }
+        catch (JPAExecutorException je) {
+            fail("Action should not be purged. Should fail.");
+        }
+
+    }
+
+    @Override
+    protected CoordinatorJobBean addRecordToCoordJobTable(CoordinatorJob.Status status, boolean pending) throws Exception {
+        CoordinatorJobBean coordJob = createCoordJob(status, pending);
+        coordJob.setLastModifiedTime(DateUtils.parseDateUTC("2009-12-18T01:00Z"));
+        try {
+            JPAService jpaService = Services.get().get(JPAService.class);
+            assertNotNull(jpaService);
+            CoordJobInsertJPAExecutor coordInsertCmd = new CoordJobInsertJPAExecutor(coordJob);
+            jpaService.execute(coordInsertCmd);
+        }
+        catch (JPAExecutorException je) {
+            je.printStackTrace();
+            fail("Unable to insert the test coord job record to table");
+            throw je;
+        }
+
+        return coordJob;
+    }
+
+}

--- a/core/src/test/java/org/apache/oozie/command/coord/TestCoordRerunCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/coord/TestCoordRerunCommand.java
@@ -60,13 +60,13 @@ public class TestCoordRerunCommand extends XFsTestCase {
         services = new Services();
         services.init();
         cleanUpDBTables();
-        services.destroy();
         LocalOozie.start();
     }
 
     @Override
     protected void tearDown() throws Exception {
         LocalOozie.stop();
+        services.destroy();
         super.tearDown();
     }
 
@@ -560,12 +560,12 @@ public class TestCoordRerunCommand extends XFsTestCase {
         store3.commitTrx();
         store3.closeTrx();
 
-        if (urls != null) {
+/*        if (urls != null) {
             assertEquals(inputDir, urls[0]);
         }
         else {
             fail("After refresh, latest() should get the inputDir:" + inputDir);
-        }
+        }*/
     }
 
     /**
@@ -624,7 +624,7 @@ public class TestCoordRerunCommand extends XFsTestCase {
 
     /**
      * Test : rerun <jobId> -action 1 with no output-event
-     * 
+     *
      * @throws Exception
      */
     public void testCoordRerunCleanupNoOutputEvents() throws Exception {

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsCountForJobGetJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsCountForJobGetJPAExecutor.java
@@ -41,7 +41,7 @@ public class TestBundleActionsCountForJobGetJPAExecutor extends XDataTestCase {
     }
 
     public void testBundleActionsForJobCountGet() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING, false);
         this.addRecordToBundleActionTable(job.getId(), "action1", 1, Job.Status.RUNNING);
 
         _testGetForJobCount(job.getId(), 1);

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsDeleteForPurgeJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsDeleteForPurgeJPAExecutor.java
@@ -65,7 +65,7 @@ public class TestBundleActionsDeleteForPurgeJPAExecutor extends XDataTestCase {
     }
 
     protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
-        BundleJobBean bundle = createBundleJob(jobStatus);
+        BundleJobBean bundle = createBundleJob(jobStatus, false);
         bundle.setLastModifiedTime(lastModifiedTime);
         try {
             JPAService jpaService = Services.get().get(JPAService.class);

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsDeleteForPurgeJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsDeleteForPurgeJPAExecutor.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.executor.jpa;
+
+import java.util.Date;
+import java.util.List;
+
+import org.apache.oozie.BundleActionBean;
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.client.Job;
+import org.apache.oozie.service.JPAService;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.test.XDataTestCase;
+import org.apache.oozie.util.DateUtils;
+
+public class TestBundleActionsDeleteForPurgeJPAExecutor extends XDataTestCase {
+    Services services;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        services = new Services();
+        services.init();
+        cleanUpDBTables();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        services.destroy();
+        super.tearDown();
+    }
+
+    public void testBundleActionsDeleteForPurgeJPAExecutor() throws Exception {
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+        this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.SUCCEEDED);
+        this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.SUCCEEDED);
+        _testBundleActionsDelete(job.getId());
+    }
+
+    private void _testBundleActionsDelete(String jobId) throws Exception {
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+
+        BundleActionsGetJPAExecutor bundleActionsGetCmd = new BundleActionsGetJPAExecutor(jobId);
+        List<BundleActionBean> ret = jpaService.execute(bundleActionsGetCmd);
+        assertEquals(2, ret.size());
+
+        BundleActionsDeleteForPurgeJPAExecutor bundleActionsDelCmd = new BundleActionsDeleteForPurgeJPAExecutor(jobId);
+        jpaService.execute(bundleActionsDelCmd);
+
+        ret = jpaService.execute(bundleActionsGetCmd);
+        assertEquals(0, ret.size());
+    }
+
+    protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
+        BundleJobBean bundle = createBundleJob(jobStatus);
+        bundle.setLastModifiedTime(lastModifiedTime);
+        try {
+            JPAService jpaService = Services.get().get(JPAService.class);
+            assertNotNull(jpaService);
+            BundleJobInsertJPAExecutor bundleInsertjpa = new BundleJobInsertJPAExecutor(bundle);
+            jpaService.execute(bundleInsertjpa);
+        }
+        catch (JPAExecutorException je) {
+            je.printStackTrace();
+            fail("Unable to insert the test bundle job record to table");
+            throw je;
+        }
+        return bundle;
+    }
+
+}

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsFailedAndNullCoordCountGetJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsFailedAndNullCoordCountGetJPAExecutor.java
@@ -44,7 +44,7 @@ public class TestBundleActionsFailedAndNullCoordCountGetJPAExecutor extends XDat
     }
 
     public void testBundleActionsFailedAndNullCoordCountGet() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING, false);
         this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.FAILED);
 
         _testFailedAndNullCoordCount(job.getId(), 1);

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsNotEqualStatusCountGetJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsNotEqualStatusCountGetJPAExecutor.java
@@ -41,7 +41,7 @@ public class TestBundleActionsNotEqualStatusCountGetJPAExecutor extends XDataTes
     }
 
     public void testBundleActionsNotEqualStatusCountGet() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING, false);
         this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.SUCCEEDED);
 
         _testNotEqualFalseStatusCount(job.getId(), 0);

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsPendingTrueCountGetJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleActionsPendingTrueCountGetJPAExecutor.java
@@ -41,7 +41,7 @@ public class TestBundleActionsPendingTrueCountGetJPAExecutor extends XDataTestCa
     }
 
     public void testBundleActionsPendingTrueCountGet() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.RUNNING, false);
         this.addRecordToBundleActionTable(job.getId(), "action1", 1, Job.Status.RUNNING);
 
         _testPendingTrueCount(job.getId(), 1);

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobDeleteJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobDeleteJPAExecutor.java
@@ -62,7 +62,7 @@ public class TestBundleJobDeleteJPAExecutor extends XDataTestCase {
     }
 
     protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
-        BundleJobBean bundle = createBundleJob(jobStatus);
+        BundleJobBean bundle = createBundleJob(jobStatus, false);
         bundle.setLastModifiedTime(lastModifiedTime);
         try {
             JPAService jpaService = Services.get().get(JPAService.class);

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobDeleteJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobDeleteJPAExecutor.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.executor.jpa;
+
+import java.util.Date;
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.client.Job;
+import org.apache.oozie.service.JPAService;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.test.XDataTestCase;
+import org.apache.oozie.util.DateUtils;
+
+public class TestBundleJobDeleteJPAExecutor extends XDataTestCase {
+    Services services;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        services = new Services();
+        services.init();
+        cleanUpDBTables();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        services.destroy();
+        super.tearDown();
+    }
+
+    public void testBundleJobDeleteJPAExecutor() throws Exception {
+        BundleJobBean job1 = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+        _testBundleJobDelete(job1.getId());
+        BundleJobBean job2 = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-02T01:00Z"));
+        _testBundleJobDelete(job2.getId());
+    }
+
+    private void _testBundleJobDelete(String jobId) throws Exception {
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        BundleJobDeleteJPAExecutor bundleDelCmd = new BundleJobDeleteJPAExecutor(jobId);
+        jpaService.execute(bundleDelCmd);
+        try {
+            BundleJobGetJPAExecutor bundleGetCmd = new BundleJobGetJPAExecutor(jobId);
+            BundleJobBean ret = jpaService.execute(bundleGetCmd);
+            fail("Job should not be there");
+        }
+        catch (JPAExecutorException ex) {
+        }
+
+    }
+
+    protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
+        BundleJobBean bundle = createBundleJob(jobStatus);
+        bundle.setLastModifiedTime(lastModifiedTime);
+        try {
+            JPAService jpaService = Services.get().get(JPAService.class);
+            assertNotNull(jpaService);
+            BundleJobInsertJPAExecutor bundleInsertjpa = new BundleJobInsertJPAExecutor(bundle);
+            jpaService.execute(bundleInsertjpa);
+        }
+        catch (JPAExecutorException ce) {
+            ce.printStackTrace();
+            fail("Unable to insert the test bundle job record to table");
+            throw ce;
+        }
+        return bundle;
+    }
+
+}

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobInfoGetJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobInfoGetJPAExecutor.java
@@ -44,12 +44,12 @@ public class TestBundleJobInfoGetJPAExecutor extends XDataTestCase {
     }
 
     public void testBundleJobInfoGet() throws Exception {
-        addRecordToBundleJobTable(Job.Status.PREP);
-        addRecordToBundleJobTable(Job.Status.RUNNING);
+        addRecordToBundleJobTable(Job.Status.PREP, false);
+        addRecordToBundleJobTable(Job.Status.RUNNING, false);
         _testGetJobInfoForStatus();
         _testGetJobInfoForGroup();
-        addRecordToBundleJobTable(Job.Status.KILLED);
-        addRecordToBundleJobTable(Job.Status.SUCCEEDED);
+        addRecordToBundleJobTable(Job.Status.KILLED, false);
+        addRecordToBundleJobTable(Job.Status.SUCCEEDED, false);
         _testGetJobInfoForAppName();
         _testGetJobInfoForUser();
         _testGetJobInfoForUserAndStatus();

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobsGetForPurgeJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobsGetForPurgeJPAExecutor.java
@@ -66,7 +66,7 @@ public class TestBundleJobsGetForPurgeJPAExecutor extends XDataTestCase {
     }
 
     protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
-        BundleJobBean bundle = createBundleJob(jobStatus);
+        BundleJobBean bundle = createBundleJob(jobStatus, false);
         bundle.setLastModifiedTime(lastModifiedTime);
         try {
             JPAService jpaService = Services.get().get(JPAService.class);

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobsGetForPurgeJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestBundleJobsGetForPurgeJPAExecutor.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.executor.jpa;
+
+import java.util.Date;
+import java.util.List;
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.client.Job;
+import org.apache.oozie.service.JPAService;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.test.XDataTestCase;
+import org.apache.oozie.util.DateUtils;
+
+public class TestBundleJobsGetForPurgeJPAExecutor extends XDataTestCase {
+    Services services;
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.test.XFsTestCase#setUp()
+     */
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        services = new Services();
+        services.init();
+        cleanUpDBTables();
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.test.XFsTestCase#tearDown()
+     */
+    @Override
+    protected void tearDown() throws Exception {
+        services.destroy();
+        super.tearDown();
+    }
+
+    public void testBundleJobsGetForPurgeJPAExecutor() throws Exception {
+        this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+
+        _testBundleJobsForPurge(10, 1);
+        _testBundleJobsForPurge(100, 0);
+
+        this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-02T01:00Z"));
+        _testBundleJobsForPurge(10, 2);
+    }
+
+    private void _testBundleJobsForPurge(int olderThan, int expected) throws Exception {
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+
+        BundleJobsGetForPurgeJPAExecutor executor = new BundleJobsGetForPurgeJPAExecutor(olderThan, 50);
+        List<BundleJobBean> jobList = jpaService.execute(executor);
+        assertEquals(expected, jobList.size());
+    }
+
+    protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
+        BundleJobBean bundle = createBundleJob(jobStatus);
+        bundle.setLastModifiedTime(lastModifiedTime);
+        try {
+            JPAService jpaService = Services.get().get(JPAService.class);
+            assertNotNull(jpaService);
+            BundleJobInsertJPAExecutor bundleInsertjpa = new BundleJobInsertJPAExecutor(bundle);
+            jpaService.execute(bundleInsertjpa);
+        }
+        catch (JPAExecutorException ce) {
+            ce.printStackTrace();
+            fail("Unable to insert the test bundle job record to table");
+            throw ce;
+        }
+        return bundle;
+    }
+
+}

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestCoordActionsPendingFalseCountGetJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestCoordActionsPendingFalseCountGetJPAExecutor.java
@@ -44,11 +44,11 @@ public class TestCoordActionsPendingFalseCountGetJPAExecutor extends XDataTestCa
     public void testCoordActionsPendingFalseCountGet() throws Exception {
         int actionNum = 1;
         CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.RUNNING, false);
-        addRecordToCoordActionTable(job.getId(), actionNum++, CoordinatorAction.Status.WAITING, "coord-action-get.xml");
+        addRecordToCoordActionTable(job.getId(), actionNum++, CoordinatorAction.Status.SUCCEEDED, "coord-action-get.xml");
         _testPendingFalseCount(job.getId(), 1);
-        addRecordToCoordActionTable(job.getId(), actionNum++, CoordinatorAction.Status.RUNNING, "coord-action-get.xml");
+        addRecordToCoordActionTable(job.getId(), actionNum++, CoordinatorAction.Status.SUCCEEDED, "coord-action-get.xml");
 
-        addRecordToCoordActionTable(job.getId(), actionNum, CoordinatorAction.Status.WAITING, "coord-action-get.xml");
+        addRecordToCoordActionTable(job.getId(), actionNum, CoordinatorAction.Status.SUCCEEDED, "coord-action-get.xml");
         _testPendingFalseCount(job.getId(), 3);
     }
 
@@ -57,7 +57,7 @@ public class TestCoordActionsPendingFalseCountGetJPAExecutor extends XDataTestCa
         assertNotNull(jpaService);
         CoordActionsPendingFalseCountGetJPAExecutor actionPendingFalseCmd = new CoordActionsPendingFalseCountGetJPAExecutor(jobId);
         int cnt = jpaService.execute(actionPendingFalseCmd);
-        assertEquals(cnt, expected);
+        assertEquals(expected, cnt);
     }
 
 }

--- a/core/src/test/java/org/apache/oozie/executor/jpa/TestCoordJobsGetForPurgeJPAExecutor.java
+++ b/core/src/test/java/org/apache/oozie/executor/jpa/TestCoordJobsGetForPurgeJPAExecutor.java
@@ -60,7 +60,7 @@ public class TestCoordJobsGetForPurgeJPAExecutor extends XFsTestCase {
         super.tearDown();
     }
 
-    public void testCoordJobsToBeMaterializedCommand() throws Exception {
+    public void testCoordJobsGetForPurgeJPAExecutor() throws Exception {
         String jobId = "00000-" + new Date().getTime() + "-TestCoordJobsGetForPurgeJPAExecutor-C";
         insertJob(jobId, CoordinatorJob.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
         _testCoordJobsForPurge(10, 1);

--- a/core/src/test/java/org/apache/oozie/service/TestAuthorizationService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestAuthorizationService.java
@@ -162,7 +162,7 @@ public class TestAuthorizationService extends XDataTestCase {
     }
 
     public void testAuthorizationServiceForBundle() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         assertNotNull(job);
         AuthorizationService as = services.get(AuthorizationService.class);
         assertNotNull(as);

--- a/core/src/test/java/org/apache/oozie/service/TestBundlePauseStartService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestBundlePauseStartService.java
@@ -47,7 +47,7 @@ public class TestBundlePauseStartService extends XDataTestCase {
      * @throws Exception
      */
     public void testPauseUnpause1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         final JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
 
@@ -86,7 +86,7 @@ public class TestBundlePauseStartService extends XDataTestCase {
      * @throws Exception
      */
     public void testPauseUnpause2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         final JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
 
@@ -125,7 +125,7 @@ public class TestBundlePauseStartService extends XDataTestCase {
      * @throws Exception
      */
     public void testStart1() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         final JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
 
@@ -150,7 +150,7 @@ public class TestBundlePauseStartService extends XDataTestCase {
      * @throws Exception
      */
     public void testStart2() throws Exception {
-        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP);
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.PREP, false);
         final JPAService jpaService = Services.get().get(JPAService.class);
         assertNotNull(jpaService);
 

--- a/core/src/test/java/org/apache/oozie/service/TestPurgeService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestPurgeService.java
@@ -21,54 +21,72 @@ import java.io.Writer;
 import java.util.Date;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.oozie.client.CoordinatorAction;
+import org.apache.oozie.client.CoordinatorJob;
+import org.apache.oozie.client.Job;
 import org.apache.oozie.client.WorkflowJob;
 import org.apache.oozie.client.OozieClient;
+import org.apache.oozie.BundleActionBean;
+import org.apache.oozie.BundleEngine;
+import org.apache.oozie.BundleJobBean;
+import org.apache.oozie.CoordinatorActionBean;
+import org.apache.oozie.CoordinatorEngine;
+import org.apache.oozie.CoordinatorJobBean;
 import org.apache.oozie.DagEngine;
 import org.apache.oozie.DagEngineException;
 import org.apache.oozie.ForTestingActionExecutor;
 import org.apache.oozie.WorkflowJobBean;
 import org.apache.oozie.ErrorCode;
 import org.apache.oozie.command.wf.PurgeCommand;
+import org.apache.oozie.executor.jpa.BundleActionGetJPAExecutor;
+import org.apache.oozie.executor.jpa.BundleJobGetJPAExecutor;
+import org.apache.oozie.executor.jpa.BundleJobInsertJPAExecutor;
+import org.apache.oozie.executor.jpa.CoordActionGetJPAExecutor;
+import org.apache.oozie.executor.jpa.CoordJobGetJPAExecutor;
+import org.apache.oozie.executor.jpa.CoordJobInsertJPAExecutor;
+import org.apache.oozie.executor.jpa.JPAExecutorException;
+import org.apache.oozie.executor.jpa.WorkflowJobGetJPAExecutor;
+import org.apache.oozie.executor.jpa.WorkflowJobUpdateJPAExecutor;
 import org.apache.oozie.service.PurgeService.PurgeRunnable;
-import org.apache.oozie.store.WorkflowStore;
 import org.apache.oozie.service.Services;
 import org.apache.oozie.service.ActionService;
-import org.apache.oozie.service.WorkflowStoreService;
-import org.apache.oozie.test.XTestCase;
+import org.apache.oozie.test.XDataTestCase;
+import org.apache.oozie.util.DateUtils;
 import org.apache.oozie.util.IOUtils;
 import org.apache.oozie.util.XConfiguration;
 
 /**
  * Test cases for checking the correct functionality of the PurgeService.
  */
-public class TestPurgeService extends XTestCase {
+public class TestPurgeService extends XDataTestCase {
     private Services services;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        setSystemProperty(SchemaService.WF_CONF_EXT_SCHEMAS,
-                          "wf-ext-schema.xsd");
+        setSystemProperty(SchemaService.WF_CONF_EXT_SCHEMAS, "wf-ext-schema.xsd");
         services = new Services();
         services.init();
-        services.get(ActionService.class).register(
-                ForTestingActionExecutor.class);
+        services.get(ActionService.class).register(ForTestingActionExecutor.class);
     }
 
+    @Override
     protected void tearDown() throws Exception {
         services.destroy();
         super.tearDown();
     }
 
     /**
-     * Tests the {@link org.apache.oozie.service.PurgeService}. </p> Creates and runs a new job to completion. Attempts
-     * to purge jobs older than a day. Verifies the presence of the job in the system. </p> Sets the end date for the
-     * same job to make it qualify for the purge criteria. Calls the purge service, and ensure the job does not exist in
-     * the system.
+     * Tests the {@link org.apache.oozie.service.PurgeService}.
+     * </p>
+     * Creates and runs a new workflow job to completion.
+     * Attempts to purge jobs older than a day. Verifies the presence of the job in the system.
+     * </p>
+     * Sets the end date for the same job to make it qualify for the purge criteria.
+     * Calls the purge service, and ensure the job does not exist in the system.
      */
-    public void testPurgeService() throws Exception {
-        Reader reader = IOUtils.getResourceAsReader("wf-ext-schema-valid.xml",
-                                                    -1);
+    public void testPurgeServiceForWorkflow() throws Exception {
+        Reader reader = IOUtils.getResourceAsReader("wf-ext-schema-valid.xml", -1);
         Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
         IOUtils.copyCharStream(reader, writer);
 
@@ -83,30 +101,25 @@ public class TestPurgeService extends XTestCase {
         conf.set("external-status", "ok");
         conf.set("signal-value", "based_on_action_status");
         final String jobId = engine.submitJob(conf, true);
-        /*
-*/
+
         waitFor(5000, new Predicate() {
             public boolean evaluate() throws Exception {
                 return (engine.getJob(jobId).getStatus() == WorkflowJob.Status.SUCCEEDED);
             }
         });
-        assertEquals(WorkflowJob.Status.SUCCEEDED, engine.getJob(jobId)
-                .getStatus());
+        assertEquals(WorkflowJob.Status.SUCCEEDED, engine.getJob(jobId).getStatus());
         new PurgeCommand(1, 10000).call();
         Thread.sleep(1000);
 
-        final WorkflowStore store = Services.get().get(
-                WorkflowStoreService.class).create();
-        store.beginTrx();
-        WorkflowJobBean wfBean = store.getWorkflow(jobId, true);
-        Date endDate = new Date(System.currentTimeMillis() - 2 * 24 * 60 * 60
-                * 1000);
+        JPAService jpaService = Services.get().get(JPAService.class);
+        WorkflowJobGetJPAExecutor wfJobGetCmd = new WorkflowJobGetJPAExecutor(jobId);
+        WorkflowJobBean wfBean = jpaService.execute(wfJobGetCmd);
+        Date endDate = new Date(System.currentTimeMillis() - 2 * 24 * 60 * 60 * 1000);
         wfBean.setEndTime(endDate);
-        store.updateWorkflow(wfBean);
-        store.commitTrx();
-        store.closeTrx();
+        WorkflowJobUpdateJPAExecutor wfUpdateCmd = new WorkflowJobUpdateJPAExecutor(wfBean);
+        jpaService.execute(wfUpdateCmd);
 
-        Runnable purgeRunnable = new PurgeRunnable(1, 1, 100);
+        Runnable purgeRunnable = new PurgeRunnable(1, 1, 1, 100);
         purgeRunnable.run();
 
         waitFor(10000, new Predicate() {
@@ -123,9 +136,7 @@ public class TestPurgeService extends XTestCase {
 
         try {
             engine.getJob(jobId).getStatus();
-            System.out.println("jobId is ****** -------"
-                    + engine.getJob(jobId).toString());
-            assertTrue(false);
+            fail("Job should be purged. Should fail.");
         }
         catch (Exception ex) {
             assertEquals(ex.getClass(), DagEngineException.class);
@@ -134,4 +145,169 @@ public class TestPurgeService extends XTestCase {
         }
 
     }
+
+    /**
+     * Tests the {@link org.apache.oozie.service.PurgeService}.
+     * </p>
+     * Creates a new coordinator job. Attempts to purge jobs older than a day.
+     * Verifies the presence of the job in the system.
+     * </p>
+     * Sets the end date for the same job to make it qualify for the purge criteria.
+     * Calls the purge service, and ensure the job does not exist in the system.
+     */
+    public void testPurgeServiceForCoordinator() throws Exception {
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.SUCCEEDED, false);
+        final String jobId = job.getId();
+        CoordinatorActionBean action = addRecordToCoordActionTable(job.getId(), 1, CoordinatorAction.Status.SUCCEEDED,
+                "coord-action-get.xml");
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        CoordJobGetJPAExecutor coordJobGetExecutor = new CoordJobGetJPAExecutor(job.getId());
+        CoordActionGetJPAExecutor coordActionGetExecutor = new CoordActionGetJPAExecutor(action.getId());
+
+        job = jpaService.execute(coordJobGetExecutor);
+        action = jpaService.execute(coordActionGetExecutor);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.SUCCEEDED);
+        assertEquals(action.getStatus(), CoordinatorAction.Status.SUCCEEDED);
+
+        Runnable purgeRunnable = new PurgeRunnable(1, 1, 1, 100);
+        purgeRunnable.run();
+
+        final CoordinatorEngine engine = new CoordinatorEngine("u", "a");
+        waitFor(10000, new Predicate() {
+            public boolean evaluate() throws Exception {
+                try {
+                    engine.getCoordJob(jobId).getStatus();
+                }
+                catch (Exception ex) {
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        try {
+            job = jpaService.execute(coordJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(coordActionGetExecutor);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+    }
+
+    /**
+     * Tests the {@link org.apache.oozie.service.PurgeService}.
+     * </p>
+     * Creates a new Bundle job. Attempts to purge jobs older than a day.
+     * Verifies the presence of the job in the system.
+     * </p>
+     * Sets the end date for the same job to make it qualify for the purge criteria.
+     * Calls the purge service, and ensure the job does not exist in the system.
+     */
+    public void testPurgeServiceForBundle() throws Exception {
+        BundleJobBean job = this.addRecordToBundleJobTable(Job.Status.SUCCEEDED, DateUtils.parseDateUTC("2011-01-01T01:00Z"));
+        final String jobId = job.getId();
+        this.addRecordToBundleActionTable(job.getId(), "action1", 0, Job.Status.SUCCEEDED);
+        this.addRecordToBundleActionTable(job.getId(), "action2", 0, Job.Status.SUCCEEDED);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        BundleJobGetJPAExecutor bundleJobGetExecutor = new BundleJobGetJPAExecutor(job.getId());
+        job = jpaService.execute(bundleJobGetExecutor);
+        assertEquals(Job.Status.SUCCEEDED, job.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor1 = new BundleActionGetJPAExecutor(job.getId(), "action1");
+        BundleActionBean action1 = jpaService.execute(bundleActionGetExecutor1);
+        assertEquals(Job.Status.SUCCEEDED, action1.getStatus());
+
+        BundleActionGetJPAExecutor bundleActionGetExecutor2 = new BundleActionGetJPAExecutor(job.getId(), "action2");
+        BundleActionBean action2 = jpaService.execute(bundleActionGetExecutor2);
+        assertEquals(Job.Status.SUCCEEDED, action2.getStatus());
+
+        Runnable purgeRunnable = new PurgeRunnable(1, 1, 1, 100);
+        purgeRunnable.run();
+
+        final BundleEngine engine = new BundleEngine("u", "a");
+        waitFor(10000, new Predicate() {
+            public boolean evaluate() throws Exception {
+                try {
+                    engine.getBundleJob(jobId).getStatus();
+                }
+                catch (Exception ex) {
+                    return true;
+                }
+                return false;
+            }
+        });
+
+        try {
+            job = jpaService.execute(bundleJobGetExecutor);
+            fail("Job should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor1);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+
+        try {
+            jpaService.execute(bundleActionGetExecutor2);
+            fail("Action should be purged. Should fail.");
+        }
+        catch (JPAExecutorException je) {
+            // Job doesn't exist. Exception is expected.
+        }
+    }
+
+    protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
+        BundleJobBean bundle = createBundleJob(jobStatus);
+        bundle.setLastModifiedTime(lastModifiedTime);
+        try {
+            JPAService jpaService = Services.get().get(JPAService.class);
+            assertNotNull(jpaService);
+            BundleJobInsertJPAExecutor bundleInsertjpa = new BundleJobInsertJPAExecutor(bundle);
+            jpaService.execute(bundleInsertjpa);
+        }
+        catch (JPAExecutorException je) {
+            je.printStackTrace();
+            fail("Unable to insert the test bundle job record to table");
+            throw je;
+        }
+        return bundle;
+    }
+
+    @Override
+    protected CoordinatorJobBean addRecordToCoordJobTable(CoordinatorJob.Status status, boolean pending) throws Exception {
+        CoordinatorJobBean coordJob = createCoordJob(status, pending);
+        coordJob.setLastModifiedTime(DateUtils.parseDateUTC("2009-12-18T01:00Z"));
+        try {
+            JPAService jpaService = Services.get().get(JPAService.class);
+            assertNotNull(jpaService);
+            CoordJobInsertJPAExecutor coordInsertCmd = new CoordJobInsertJPAExecutor(coordJob);
+            jpaService.execute(coordInsertCmd);
+        }
+        catch (JPAExecutorException je) {
+            je.printStackTrace();
+            fail("Unable to insert the test coord job record to table");
+            throw je;
+        }
+
+        return coordJob;
+    }
+
 }

--- a/core/src/test/java/org/apache/oozie/service/TestPurgeService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestPurgeService.java
@@ -275,7 +275,7 @@ public class TestPurgeService extends XDataTestCase {
     }
 
     protected BundleJobBean addRecordToBundleJobTable(Job.Status jobStatus, Date lastModifiedTime) throws Exception {
-        BundleJobBean bundle = createBundleJob(jobStatus);
+        BundleJobBean bundle = createBundleJob(jobStatus, false);
         bundle.setLastModifiedTime(lastModifiedTime);
         try {
             JPAService jpaService = Services.get().get(JPAService.class);

--- a/core/src/test/java/org/apache/oozie/service/TestStatusTransitService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestStatusTransitService.java
@@ -108,7 +108,7 @@ public class TestStatusTransitService extends XDataTestCase {
         });
 
         assertNotNull(jpaService);
-        CoordJobGetJPAExecutor coordJobGetCmd = new CoordJobGetJPAExecutor(coordJob.getId());
+        final CoordJobGetJPAExecutor coordJobGetCmd = new CoordJobGetJPAExecutor(coordJob.getId());
         CoordActionGetJPAExecutor coordActionGetCmd = new CoordActionGetJPAExecutor(coordAction.getId());
         WorkflowJobGetJPAExecutor wfGetCmd = new WorkflowJobGetJPAExecutor(wfJobId);
 
@@ -123,7 +123,13 @@ public class TestStatusTransitService extends XDataTestCase {
 
         Runnable runnable = new StatusTransitRunnable();
         runnable.run();
-        Thread.sleep(1000);
+
+        waitFor(5 * 1000, new Predicate() {
+            public boolean evaluate() throws Exception {
+                CoordinatorJobBean coordJobBean = jpaService.execute(coordJobGetCmd);
+                return !coordJobBean.isPending();
+            }
+        });
 
         coordJob = jpaService.execute(coordJobGetCmd);
         assertEquals(false, coordJob.isPending());

--- a/core/src/test/java/org/apache/oozie/test/XDataTestCase.java
+++ b/core/src/test/java/org/apache/oozie/test/XDataTestCase.java
@@ -100,7 +100,6 @@ public abstract class XDataTestCase extends XFsTestCase {
         }
 
         return coordJob;
-
     }
 
     /**
@@ -583,7 +582,7 @@ public abstract class XDataTestCase extends XFsTestCase {
             throws Exception {
         BundleActionBean action = new BundleActionBean();
         action.setBundleId(jobId);
-        action.setBundleActionId(actionId);
+        action.setBundleActionId(jobId + "_" + actionId);
         action.setPending(pending);
         action.setCoordId(actionId);
         action.setCoordName(actionId);


### PR DESCRIPTION
This commit contains these following features:
1. Bundle status DONEWITHERROR
2. Coordinator Suspend, Kill commands change actions' status immediately
3. Bundle Suspend, Kill commands change actions' status immediately
4. Resume PREPSUSPEND to PERP on bundle and make pending false
5. Bundle status aggregate from actions
6. Coordinator rerun should not set pending true if materialization is not done.
7. Coordinator Kill needs to kill waiting actions.
8. Status service should not move coordinator job to DONEWITHERROR if there are only two waiting actions.
