### PR TITLE
[3.0] Closes GH-0665 XCommand log object has to reset after the logInfo has reset

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/XCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/XCommand.java
@@ -56,7 +56,7 @@ public abstract class XCommand<T> implements XCallable<T> {
 
     public static final Long DEFAULT_REQUEUE_DELAY = 10L;
 
-    public final XLog LOG = XLog.getLog(getClass());
+    public XLog LOG = XLog.getLog(getClass());
 
     private String key;
     private String name;
@@ -247,6 +247,7 @@ public abstract class XCommand<T> implements XCallable<T> {
                 if (!isLockRequired() || (isLockRequired() && lock != null)) {
                     LOG.debug("Load state for [{0}]", getEntityKey());
                     loadState();
+                    LOG = XLog.getLog(getClass());
                     LOG.debug("Precondition check for command [{0}] key [{1}]", getName(), getEntityKey());
                     verifyPrecondition();
                     LOG.debug("Execute command [{0}] key [{1}]", getName(), getEntityKey());

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+GH-0665 XCommand log object has to reset after the logInfo has reset
 GH-0568 DOC: Add Bundle specifications
 GH-0482 coordinator default config is looked up in the wrong place (regression)
 GH-0653 Adding Pause status update in service. 


### PR DESCRIPTION
Closes GH-0665 XCommand log object has to reset after the logInfo has reset
