### PR TITLE
Closes OOZIE-19 oozie-setup.sh should add JARs from an extension director

### DIFF
--- a/distro/src/main/bin/oozie-setup.sh
+++ b/distro/src/main/bin/oozie-setup.sh
@@ -121,8 +121,29 @@ rm -rf ${outputWarExpanded}
 
 echo
 
+# Adding extension JARs
+
+libext=${OOZIE_HOME}/libext
+if [ -d "${libext}" ]; then
+  if [ `ls ${libext} | grep \.jar\$ | wc -c` != 0 ]; then
+    for i in "${libext}/"*.jar; do
+      echo "INFO: Adding extension: $i"
+      jarsPath="${jarsPath}:$i"
+      addJars="true"
+    done
+  fi
+  if [ -f "${libext}/ext-2.2.zip" ]; then
+    extjsHome=${libext}/ext-2.2.zip
+    addExtjs=true
+  fi  
+fi
+
+if [ "${addExtjs}" == "" ]; then
+  echo "INFO: Oozie webconsole disabled, ExtJS library not specified"
+fi
+
 if [ "${addExtjs}${addJars}${addHadoopJars}" == "" ]; then
-  echo "INFO: Doing default installation, Oozie webconsole disabled"
+  echo "INFO: Doing default installation"
   cp ${inputWar} ${outputWar}
 else
   OPTIONS=""

--- a/docs/src/site/twiki/AG_Install.twiki
+++ b/docs/src/site/twiki/AG_Install.twiki
@@ -46,9 +46,9 @@ value is undefined and interpreted as a =false=.
 
 ---++ Oozie Server Setup
 
-The =setup-oozie.sh= script prepares the embedded Tomcat server to run Oozie.
+The =oozie-setup.sh= script prepares the embedded Tomcat server to run Oozie.
 
-The =setup-oozie.sh= script options are:
+The =oozie-setup.sh= script options are:
 
 <verbatim>
 Usage  : oozie-setup.sh <OPTIONS>"
@@ -58,6 +58,12 @@ Usage  : oozie-setup.sh <OPTIONS>"
          [-jars JARS_PATH] (multiple JAR path separated by ':')"
          (without options does default setup, without the Oozie webconsole)"
 </verbatim>
+
+If a directory =libext/= is present in Oozie installation directory, the =oozie-setup.sh= script
+include all JARs in the =libext/= directory in Oozie WAR file.
+
+If the ExtJS ZIP file is present in the =libext/= directory, it will be added to Oozie WAR as well.
+The ExtJS library file name be =ext-2.2.zip=.
 
 ---+++ Setting Up Oozie with an Alternate Tomcat
 

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+OOZIE-19 oozie-setup.sh should add all JARs from an extensions directory
 GH-0568 DOC: Add Bundle specifications
 GH-0482 coordinator default config is looked up in the wrong place (regression)
 GH-0653 Adding Pause status update in service. 


### PR DESCRIPTION
Closes OOZIE-19 oozie-setup.sh should add JARs from an extension directory automatically
