### PR TITLE
Closes OOZIE-21 modify the POM to enable exclusion of testcases via comma

### DIFF
--- a/docs/src/site/twiki/ENG_Building.twiki
+++ b/docs/src/site/twiki/ENG_Building.twiki
@@ -180,6 +180,10 @@ The =oozietests= directory is used by testcases when they need a local filesyste
 *hadoop.log.dir*= : specifies the directory where Hadoop minicluster will write its logs during testcases, default
 value is =/tmp=.
 
+*test.exclude*= : specifies a testcase class (just the class name) to exclude for the tests run, for example =TestSubmitCommand=.
+
+*test.exclude.pattern*= : specifies one or more patterns for testcases to exclude, for example =**/Test*Command.java=.
+
 ---++ Building an Oozie Distribution
 
 An Oozie distribution bundles an embedded Tomcat server. The Oozie distro module downloads Tomcat TAR.GZ from Apache

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+        <test.exclude>_</test.exclude>
+        <test.exclude.pattern>_</test.exclude.pattern>
     </properties>
 
     <modules>
@@ -551,6 +553,10 @@
                     <systemPropertiesVariables>
                         <hadoop.log.dir>/tmp</hadoop.log.dir>
                     </systemPropertiesVariables>
+                    <excludes>
+                        <exclude>**/${test.exclude}.java</exclude>
+                        <exclude>${test.exclude.pattern}</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+OOZIE-21 modify the POM to enable exclusion of testcases via command line when invoking maven
 GH-0568 DOC: Add Bundle specifications
 GH-0482 coordinator default config is looked up in the wrong place (regression)
 GH-0653 Adding Pause status update in service. 


### PR DESCRIPTION
Closes OOZIE-21 modify the POM to enable exclusion of testcases via command line when invoking maven
