### PR TITLE
Oozie 34bp23

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/hadoop/LauncherMapper.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/LauncherMapper.java
@@ -624,6 +624,14 @@ class LauncherSecurityManager extends SecurityManager {
     }
 
     @Override
+    public void checkPermission(Permission perm, Object context) {
+        if (securityManager != null) {
+            // check everything with the original SecurityManager
+            securityManager.checkPermission(perm, context);
+        }
+    }
+
+    @Override
     public void checkPermission(Permission perm) {
         if (securityManager != null) {
             // check everything with the original SecurityManager

--- a/core/src/test/java/org/apache/oozie/action/hadoop/LauncherMainTester.java
+++ b/core/src/test/java/org/apache/oozie/action/hadoop/LauncherMainTester.java
@@ -53,6 +53,18 @@ public class LauncherMainTester {
                 os.close();
                 System.out.println(file.getAbsolutePath());
             }
+            if (args[0].equals("securityManager")) {
+                SecurityManager sm = System.getSecurityManager();
+                if (sm == null) {
+                    throw new Throwable("no security manager");
+                }
+                // by using NULL as permission, if an underlaying SecurityManager is in place
+                // a security exception will be thrown. As there is not underlaying SecurityManager
+                // this tests that the delegation logic of the LauncherMapper SecurityManager is
+                // correct for both checkPermission() signatures.
+                sm.checkPermission(null);
+                sm.checkPermission(null, sm.getSecurityContext());
+            }
         }
     }
 

--- a/core/src/test/java/org/apache/oozie/action/hadoop/TestLauncher.java
+++ b/core/src/test/java/org/apache/oozie/action/hadoop/TestLauncher.java
@@ -186,4 +186,21 @@ public class TestLauncher extends XFsTestCase {
         assertFalse(fs.exists(LauncherMapper.getOutputDataPath(actionDir)));
     }
 
+    public void testSecurityManager() throws Exception {
+        Path actionDir = getFsTestCaseDir();
+        FileSystem fs = getFileSystem();
+        RunningJob runningJob = _test("securityManager");
+        Thread.sleep(2000);
+        assertTrue(runningJob.isSuccessful());
+
+        assertTrue(LauncherMapper.isMainDone(runningJob));
+        assertTrue(LauncherMapper.isMainSuccessful(runningJob));
+        assertFalse(LauncherMapper.hasOutputData(runningJob));
+        assertFalse(LauncherMapper.hasIdSwap(runningJob));
+        assertTrue(LauncherMapper.isMainDone(runningJob));
+        assertFalse(fs.exists(LauncherMapper.getErrorPath(actionDir)));
+        assertFalse(fs.exists(LauncherMapper.getIdSwapPath(actionDir)));
+        assertFalse(fs.exists(LauncherMapper.getOutputDataPath(actionDir)));
+    }
+
 }

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.2 release
 
+OOZIE-34 LauncherMapper security manager fails when a permission with context is check
 OOZIE-21 modify the POM to enable exclusion of testcases via command line when invoking maven
 OOZIE-20 examples job properties have hardcoded values, and use non-default Hadoop ports
 OOZIE-19 oozie-setup.sh should add all JARs from an extensions directory


### PR DESCRIPTION
Closes OOZIE-34 LauncherMapper security manager fails when a permission with context is check
