### PR TITLE
[3.0] OOZIE-36 rerun a paused coordinator job should not reset status and pause time and pending flag

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/coord/CoordRerunXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordRerunXCommand.java
@@ -498,10 +498,16 @@ public class CoordRerunXCommand extends RerunTransitionXCommand<CoordinatorActio
 
     @Override
     public void updateJob() throws CommandException {
+        // rerun a paused coordinator job will keep job status at paused and pending at previous pending
         if (prevStatus.equals(Job.Status.PAUSED)) {
-            coordJob.setPauseTime(null);
+            coordJob.setStatus(Job.Status.PAUSED);
+            if (prevPending) {
+                coordJob.setPending();
+            }
         }
-        updateCoordJobPending();
+        else {
+            updateCoordJobPending();
+        }
         try {
             jpaService.execute(new CoordJobUpdateJPAExecutor(coordJob));
         }

--- a/core/src/test/java/org/apache/oozie/command/coord/TestCoordRerunXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/coord/TestCoordRerunXCommand.java
@@ -690,8 +690,8 @@ public class TestCoordRerunXCommand extends XDataTestCase {
                 .call();
 
         job = jpaService.execute(coordJobGetExecutor);
-        assertEquals(Job.Status.RUNNING, job.getStatus());
-        assertNull(job.getPauseTime());
+        assertEquals(Job.Status.PAUSED, job.getStatus());
+        assertNotNull(job.getPauseTime());
     }
 
     /**

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+OOZIE-36 rerun a paused coordinator job should not reset status and pause time and pending flag
 OOZIE-31 reset pending for coordjob with running pending true when change end time
 OOZIE-30 set coord paused time to null when rerun a paused coord job
 OOZIE-29 bundle rerun by name only doesn't work.


### PR DESCRIPTION
Closes OOZIE-36 rerun a paused coordinator job should not reset status and pause time and pending flag
