### PR TITLE
Closes OOZIE-15 when writing action configurations to logs, properties na

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/hadoop/LauncherMain.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/LauncherMain.java
@@ -14,6 +14,11 @@
  */
 package org.apache.oozie.action.hadoop;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Map;
+
 public abstract class LauncherMain {
 
     protected static void run(Class<? extends LauncherMain> klass, String[] args) throws Exception {
@@ -22,6 +27,36 @@ public abstract class LauncherMain {
     }
 
     protected abstract void run(String[] args) throws Exception;
+
+    /**
+     * Write to STDOUT (the task log) the Configuration/Properties values. All properties that contain
+     * any of the strings in the maskSet will be masked when writting it to STDOUT.
+     *
+     * @param header message for the beginning of the Configuration/Properties dump.
+     * @param maskSet set with substrings of property names to mask.
+     * @param conf Configuration/Properties object to dump to STDOUT
+     * @throws IOException thrown if an IO error ocurred.
+     */
+    @SuppressWarnings("unchecked")
+    protected static void logMasking(String header, Collection<String> maskSet, Iterable conf) throws IOException {
+        StringWriter writer = new StringWriter();
+        writer.write(header + "\n");
+        writer.write("--------------------\n");
+        for (Map.Entry entry : (Iterable<Map.Entry>) conf){
+            String name = (String) entry.getKey();
+            String value = (String) entry.getValue();
+            for (String mask : maskSet) {
+                if (name.contains(mask)) {
+                    value = "*MASKED*";
+                }
+            }
+            writer.write(" " + name + " : " + value + "\n");
+        }
+        writer.write("--------------------\n");
+        writer.close();
+        System.out.println(writer.toString());
+        System.out.flush();
+    }
 
 }
 

--- a/core/src/main/java/org/apache/oozie/action/hadoop/MapReduceMain.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/MapReduceMain.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.io.ByteArrayOutputStream;
@@ -45,14 +46,7 @@ public class MapReduceMain extends LauncherMain {
         Configuration actionConf = new Configuration(false);
         actionConf.addResource(new Path("file:///", System.getProperty("oozie.action.conf.xml")));
 
-        System.out.println("Oozie Map-Reduce Configuration: ");
-        System.out.println("------------------------");
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        actionConf.writeXml(baos);
-        baos.close();
-        System.out.println(new String(baos.toByteArray()));
-        System.out.println("------------------------");
-        System.out.println();
+        logMasking("Map-Reduce job configuration:", new HashSet<String>(), actionConf);
 
         System.out.println("Submitting Oozie action Map-Reduce job");
         System.out.println();

--- a/core/src/main/java/org/apache/oozie/action/hadoop/PigMain.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/PigMain.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.List;
@@ -101,13 +102,7 @@ public class PigMain extends LauncherMain {
         pigProperties.store(os, "");
         os.close();
 
-        System.out.println();
-        System.out.println("pig.properties content:");
-        System.out.println("------------------------");
-        pigProperties.store(System.out, "");
-        System.out.flush();
-        System.out.println("------------------------");
-        System.out.println();
+        logMasking("pig.properties:", Arrays.asList("password"), pigProperties.entrySet());
 
         List<String> arguments = new ArrayList<String>();
         String script = actionConf.get("oozie.pig.script");

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.0 release
 
+OOZIE-15 when writing action configurations to logs, properties names containing 'password' should be masked
 OOZIE-36 rerun a paused coordinator job should not reset status and pause time and pending flag
 OOZIE-33 Fixing coord job status when all actions in SUSPENDED  
 OOZIE-31 reset pending for coordjob with running pending true when change end time


### PR DESCRIPTION
Closes OOZIE-15 when writing action configurations to logs, properties names containing 'password' should be masked
