### PR TITLE
Some documentation fixes in the coordinator functional spec.

### DIFF
--- a/docs/src/site/twiki/CoordinatorFunctionalSpec.twiki
+++ b/docs/src/site/twiki/CoordinatorFunctionalSpec.twiki
@@ -1970,11 +1970,11 @@ For example, if baseDate is '2009-01-01T00:00Z', instance is '2' and timeUnit is
           <configuration>
             <property>
               <name>nextInstance</name>
-              <value>${coord:dateOffset(coord:nominalTime(), 1, 'DAY'}</value>
+              <value>${coord:dateOffset(coord:nominalTime(), 1, 'DAY')}</value>
             </property>
             <property>
              <name>previousInstance</name>
-              <value>${coord:dateOffset(coord:nominalTime(), -1, 'DAY'}</value>
+              <value>${coord:dateOffset(coord:nominalTime(), -1, 'DAY')}</value>
             </property>
          </configuration>
        </workflow>

--- a/docs/src/site/twiki/CoordinatorFunctionalSpec.twiki
+++ b/docs/src/site/twiki/CoordinatorFunctionalSpec.twiki
@@ -1942,7 +1942,7 @@ The nominal times for the coordinator actions of this coordinator application ex
 
 These are the times the action where created (materialized).
 
----++++ 6.7.4. coord:nominalTime() EL Function (since Oozie 2.3)
+---++++ 6.7.4. coord:user() EL Function (since Oozie 2.3)
 
 The =coord:user()= function returns the user that started the coordinator job.
 


### PR DESCRIPTION
One is for the new coord:user() function (it is named as nominalTime in the header.)

Other's examples shown in the coord:dateOffset functions.
