### PR TITLE
[3.0.1] OOZIE-45 coord job set to DONEWITHERROR when coord actions are TIM

### DIFF
--- a/core/src/main/java/org/apache/oozie/service/StatusTransitService.java
+++ b/core/src/main/java/org/apache/oozie/service/StatusTransitService.java
@@ -262,12 +262,12 @@ public class StatusTransitService implements Service {
 
                     if (checkCoordTerminalStatus(coordActionStatus, coordActions, coordStatus)) {
                         LOG.info("Coord job [" + jobId + "] Status set to " + coordStatus[0].toString());
-                        updateCoordJob(coordActionStatus,coordActions,coordJob, coordStatus[0]);
+                        updateCoordJob(coordActionStatus, coordActions, coordJob, coordStatus[0]);
                         continue;
                     }
                     else if (checkCoordSuspendStatus(coordActionStatus, coordActions, coordStatus)) {
                         LOG.info("Coord job [" + jobId + "] Status set to " + coordStatus[0].toString());
-                        updateCoordJob(coordActionStatus,coordActions,coordJob, coordStatus[0]);
+                        updateCoordJob(coordActionStatus, coordActions, coordJob, coordStatus[0]);
                         continue;
                     }
                 }
@@ -342,23 +342,18 @@ public class StatusTransitService implements Service {
             }
 
             if (coordActions.size() == (totalValuesSucceed + totalValuesFailed + totalValuesKilled + totalValuesTimeOut)) {
-                // If all the bundle actions are succeeded then bundle job should be succeeded.
+                // If all the coordinator actions are succeeded then coordinator job should be succeeded.
                 if (coordActions.size() == totalValuesSucceed) {
                     coordStatus[0] = Job.Status.SUCCEEDED;
                     ret = true;
                 }
                 else if (coordActions.size() == totalValuesKilled) {
-                    // If all the bundle actions are KILLED then bundle job should be KILLED.
+                    // If all the coordinator actions are KILLED then coordinator job should be KILLED.
                     coordStatus[0] = Job.Status.KILLED;
                     ret = true;
                 }
                 else if (coordActions.size() == totalValuesFailed) {
-                    // If all the bundle actions are FAILED then bundle job should be FAILED.
-                    coordStatus[0] = Job.Status.FAILED;
-                    ret = true;
-                }
-                else if (coordActions.size() == totalValuesTimeOut) {
-                    // If all the bundle actions are TIMEOUT then bundle job should be FAILED.
+                    // If all the coordinator actions are FAILED then coordinator job should be FAILED.
                     coordStatus[0] = Job.Status.FAILED;
                     ret = true;
                 }

--- a/core/src/test/java/org/apache/oozie/service/TestStatusTransitService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestStatusTransitService.java
@@ -146,6 +146,32 @@ public class TestStatusTransitService extends XDataTestCase {
         assertEquals(false, coordJob.isPending());
     }
 
+    /**
+     * Tests functionality of the StatusTransitService Runnable command. </p> Insert a coordinator job with RUNNING and
+     * pending true and coordinator actions with TIMEDOUT state. Then, runs the StatusTransitService runnable
+     * and ensures the job state changes to DONEWITHERROR.
+     *
+     * @throws Exception
+     */
+    public void testCoordStatusTransitServiceForTimeout() throws Exception {
+        Date start = DateUtils.parseDateUTC("2009-02-01T01:00Z");
+        Date end = DateUtils.parseDateUTC("2009-02-02T23:59Z");
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.RUNNING, start, end, true, 3);
+        addRecordToCoordActionTable(job.getId(), 1, CoordinatorAction.Status.TIMEDOUT, "coord-action-get.xml");
+        addRecordToCoordActionTable(job.getId(), 2, CoordinatorAction.Status.TIMEDOUT, "coord-action-get.xml");
+        addRecordToCoordActionTable(job.getId(), 3, CoordinatorAction.Status.TIMEDOUT, "coord-action-get.xml");
+
+        Runnable runnable = new StatusTransitRunnable();
+        runnable.run();
+        Thread.sleep(1000);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        CoordJobGetJPAExecutor coordGetCmd = new CoordJobGetJPAExecutor(job.getId());
+        CoordinatorJobBean coordJob = jpaService.execute(coordGetCmd);
+        assertEquals(CoordinatorJob.Status.DONEWITHERROR, coordJob.getStatus());
+
+    }
+
     @Override
     protected CoordinatorActionBean addRecordToCoordActionTable(String jobId, int actionNum,
             CoordinatorAction.Status status, String resourceXmlName) throws Exception {


### PR DESCRIPTION
Closes OOZIE-45 coord job set to DONEWITHERROR when coord actions are TIMEOUT

in the new status, when all actions TIMEDOUT, job status is FAILED.
in this case, the actions cannot be rerun.

14:03:18,091 INFO CoordRerunXCommand:525 - USER[strat_ci] GROUP[-] TOKEN[-] APP[-] JOB[-] ACTION[-] CoordRerunCommand
is not able to run, job status=FAILED, jobid=0000263-110407060521919-oozie-oozi-C
