### PR TITLE
[3.0.1] OOZIE-47 coordinator resume should resume PREPSUSPENDED state

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/ResumeTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/ResumeTransitionXCommand.java
@@ -57,9 +57,9 @@ public abstract class ResumeTransitionXCommand extends TransitionXCommand<Void> 
     @Override
     protected Void execute() throws CommandException {
         transitToNext();
-        updateJob();
         try {
             resumeChildren();
+            updateJob();
         } finally {
             notifyParent();
         }

--- a/core/src/main/java/org/apache/oozie/command/SuspendTransitionXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/SuspendTransitionXCommand.java
@@ -57,9 +57,9 @@ public abstract class SuspendTransitionXCommand extends TransitionXCommand<Void>
     @Override
     protected Void execute() throws CommandException {
         transitToNext();
-        updateJob();
         try {
             suspendChildren();
+            updateJob();
         } finally {
             notifyParent();
         }

--- a/core/src/main/java/org/apache/oozie/command/coord/CoordResumeXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordResumeXCommand.java
@@ -96,9 +96,9 @@ public class CoordResumeXCommand extends ResumeTransitionXCommand {
      */
     @Override
     protected void verifyPrecondition() throws CommandException, PreconditionException {
-        if (coordJob.getStatus() != CoordinatorJob.Status.SUSPENDED) {
-            throw new PreconditionException(ErrorCode.E1100, "CoordResumeCommand not Resumed - "
-                    + "job not in SUSPENDED state " + jobId);
+        if (coordJob.getStatus() != CoordinatorJob.Status.SUSPENDED && coordJob.getStatus() != Job.Status.PREPSUSPENDED) {
+            throw new PreconditionException(ErrorCode.E1100, "CoordResumeXCommand not Resumed - "
+                    + "job not in SUSPENDED/PREPSUSPENDED state, job = " + jobId);
         }
     }
 

--- a/core/src/test/java/org/apache/oozie/command/coord/TestCoordResumeXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/coord/TestCoordResumeXCommand.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.command.coord;
+
+import org.apache.oozie.CoordinatorJobBean;
+import org.apache.oozie.client.CoordinatorJob;
+import org.apache.oozie.executor.jpa.CoordJobGetJPAExecutor;
+import org.apache.oozie.service.JPAService;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.test.XDataTestCase;
+
+public class TestCoordResumeXCommand extends XDataTestCase {
+    private Services services;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        services = new Services();
+        services.init();
+        cleanUpDBTables();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        services.destroy();
+        super.tearDown();
+    }
+
+    /**
+     * Test : suspend a RUNNING coordinator job and resume to RUNNING
+     *
+     * @throws Exception
+     */
+    public void testCoordSuspendAndResumeForRunning() throws Exception {
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.RUNNING, false);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        CoordJobGetJPAExecutor coordJobGetCmd = new CoordJobGetJPAExecutor(job.getId());
+        job = jpaService.execute(coordJobGetCmd);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.RUNNING);
+
+        new CoordSuspendXCommand(job.getId()).call();
+        job = jpaService.execute(coordJobGetCmd);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.SUSPENDED);
+        assertFalse(job.isPending());
+
+        new CoordResumeXCommand(job.getId()).call();
+        job = jpaService.execute(coordJobGetCmd);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.RUNNING);
+        assertFalse(job.isPending());
+    }
+
+    /**
+     * Test : suspend a PREP coordinator job and resume to PREP
+     *
+     * @throws Exception
+     */
+    public void testCoordSuspendAndResumeForPrep() throws Exception {
+        CoordinatorJobBean job = addRecordToCoordJobTable(CoordinatorJob.Status.PREP, false);
+
+        JPAService jpaService = Services.get().get(JPAService.class);
+        assertNotNull(jpaService);
+        CoordJobGetJPAExecutor coordJobGetCmd = new CoordJobGetJPAExecutor(job.getId());
+        job = jpaService.execute(coordJobGetCmd);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.PREP);
+
+        new CoordSuspendXCommand(job.getId()).call();
+        job = jpaService.execute(coordJobGetCmd);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.PREPSUSPENDED);
+        assertFalse(job.isPending());
+
+        new CoordResumeXCommand(job.getId()).call();
+        job = jpaService.execute(coordJobGetCmd);
+        assertEquals(job.getStatus(), CoordinatorJob.Status.PREP);
+        assertFalse(job.isPending());
+    }
+}


### PR DESCRIPTION
OOZIE-47 coordinator resume should resume PREPSUSPENDED state
1. Resume command should resume status PREPSUSPENDED
2. CoordSuspendXCommand & CoordResumeXCommand should not set or reset pending since all actions are updated synchronously.
