### PR TITLE
Closes OOZIE-87 Fix for change endtime not create new actions

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/coord/CoordChangeXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordChangeXCommand.java
@@ -256,7 +256,9 @@ public class CoordChangeXCommand extends CoordinatorXCommand<Void> {
             if (newEndTime != null) {
                 coordJob.setEndTime(newEndTime);
                 if (coordJob.getStatus() == CoordinatorJob.Status.SUCCEEDED
-                        || coordJob.getStatus() == CoordinatorJob.Status.RUNNING) {
+                        || coordJob.getStatus() == CoordinatorJob.Status.RUNNING
+                        || coordJob.getStatus() == CoordinatorJob.Status.DONEWITHERROR
+                        || coordJob.getStatus() == CoordinatorJob.Status.FAILED) {
                     coordJob.setStatus(CoordinatorJob.Status.RUNNING);
                     coordJob.setPending();
                     coordJob.resetDoneMaterialization();

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.1 release
 
+OOZIE-87 Fix for change endtime not create new actions when job DONEWITHERROR/FAILED
 OOZIE-80 Make coordinator backward compatible for RUNNING and PREPSUSPENDED
 OOZIE-78 Resume coordinator actions should check the status is suspended
 OOZIE-58 Add date/time formatting function to coord.


### PR DESCRIPTION
Closes OOZIE-87 Fix for change endtime not create new actions when job DONEWITHERROR/FAILED
