### PR TITLE
Closes OOZIE-93 coordinator start and end instances doesn't work with flo

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/coord/CoordCommandUtils.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordCommandUtils.java
@@ -75,7 +75,7 @@ public class CoordCommandUtils {
         if (firstPos >= 0 && lastPos > firstPos) {
             String tmp = funcName.substring(firstPos + 1, lastPos).trim();
             if (tmp.length() > 0) {
-                return Integer.parseInt(tmp);
+                return (int) Double.parseDouble(tmp);
             }
         }
         throw new RuntimeException("Unformatted function :" + funcName);
@@ -89,7 +89,7 @@ public class CoordCommandUtils {
             String tmp = funcName.substring(firstPos + 1, secondPos).trim();
             if (tmp.length() > 0) {
                 restArg.append(funcName.substring(secondPos + 1, lastPos).trim());
-                return Integer.parseInt(tmp);
+                return (int) Double.parseDouble(tmp);
             }
         }
         throw new RuntimeException("Unformatted function :" + funcName);

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.0.1 release
 
+OOZIE-93 coordinator start and end instances doesn't work with float number.
 OOZIE-89 coord job status keep in SUCCEEDED when rerun in backward support state
 OOZIE-88 fix the status-transit-service to aggregate coordinator job running state
 OOZIE-83 add parameter userName to bundle xml in example


### PR DESCRIPTION
Closes OOZIE-93 coordinator start and end instances doesn't work with float number.
