### PR TITLE
Closes OOZIE-130 build workflow progress information in Oozie

### DIFF
--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -878,6 +878,10 @@ public class OozieCLI {
         System.out.println("Last Modified : " + maskDate(job.getLastModifiedTime(), localtime));
         System.out.println("Ended         : " + maskDate(job.getEndTime(), localtime));
         System.out.println("CoordAction ID: " + maskIfNull(job.getParentId()));
+        if (job.getProgress() >= 0) { // -1.0f means no progress is available, therefore do not display.
+            System.out.printf("%% Complete    : %.2f%%\n", job.getProgress() * 100f);
+        }
+
 
         List<WorkflowAction> actions = job.getActions();
 

--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -878,10 +878,7 @@ public class OozieCLI {
         System.out.println("Last Modified : " + maskDate(job.getLastModifiedTime(), localtime));
         System.out.println("Ended         : " + maskDate(job.getEndTime(), localtime));
         System.out.println("CoordAction ID: " + maskIfNull(job.getParentId()));
-        if (job.getProgress() >= 0) { // -1.0f means no progress is available, therefore do not display.
-            System.out.printf("%% Complete    : %.2f%%\n", job.getProgress() * 100f);
-        }
-
+        System.out.printf("%% Complete    : %.2f%%\n", job.getProgress() * 100f);
 
         List<WorkflowAction> actions = job.getActions();
 

--- a/client/src/main/java/org/apache/oozie/client/WorkflowJob.java
+++ b/client/src/main/java/org/apache/oozie/client/WorkflowJob.java
@@ -135,5 +135,10 @@ public interface WorkflowJob {
      * @return the workflow nodes that already executed and are executing.
      */
     List<WorkflowAction> getActions();
-
+    
+    /**
+     * Return the workflow job progress in %.
+     */
+    float getProgress();
+    
 }

--- a/client/src/main/java/org/apache/oozie/client/rest/JsonTags.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/JsonTags.java
@@ -45,6 +45,7 @@ public interface JsonTags {
     public static final String WORKFLOW_RUN = "run";
     public static final String WORKFLOW_CONSOLE_URL = "consoleUrl";
     public static final String WORKFLOW_ACTIONS = "actions";
+    public static final String WORKFLOW_PROGRESS = "progress";
 
     public static final String WORKFLOWS_JOBS = "workflows";
     public static final String WORKFLOWS_TOTAL = "total";

--- a/client/src/main/java/org/apache/oozie/client/rest/JsonToBean.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/JsonToBean.java
@@ -94,6 +94,7 @@ public class JsonToBean {
         WF_JOB.put("getRun", new Property(JsonTags.WORKFLOW_RUN, Integer.TYPE));
         WF_JOB.put("getConsoleUrl", new Property(JsonTags.WORKFLOW_CONSOLE_URL, String.class));
         WF_JOB.put("getActions", new Property(JsonTags.WORKFLOW_ACTIONS, WorkflowAction.class, true));
+        WF_JOB.put("getProgress", new Property(JsonTags.WORKFLOW_PROGRESS, Float.TYPE));
         WF_JOB.put("getParentId", new Property(JsonTags.WORKFLOW_PARENT_ID, String.class));
         WF_JOB.put("toString", new Property(JsonTags.TO_STRING, String.class));
 
@@ -215,6 +216,9 @@ public class JsonToBean {
             }
             else if (type == Long.TYPE) {
                 return (obj != null) ? obj : new Long(0);
+            }
+            else if (type == Float.TYPE) {
+                return (obj != null) ? new Float(((Double) obj).floatValue()) : new Float(-1);
             }
             else if (type == Date.class) {
                 return JsonUtils.parseDateRfc822((String) obj);

--- a/client/src/main/java/org/apache/oozie/client/rest/JsonToBean.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/JsonToBean.java
@@ -218,7 +218,7 @@ public class JsonToBean {
                 return (obj != null) ? obj : new Long(0);
             }
             else if (type == Float.TYPE) {
-                return (obj != null) ? new Float(((Double) obj).floatValue()) : new Float(-1);
+                return new Float(((Double) obj).floatValue());
             }
             else if (type == Date.class) {
                 return JsonUtils.parseDateRfc822((String) obj);

--- a/client/src/main/java/org/apache/oozie/client/rest/JsonUtils.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/JsonUtils.java
@@ -16,15 +16,9 @@ package org.apache.oozie.client.rest;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
-
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-
 
 /**
  * Json utils methods.
@@ -65,19 +59,4 @@ public class JsonUtils {
         }
         return null;
     }
-    
-    /**
-     * Return a float value from a JSONObject.
-     * This is used only for getting job's progress value.
-     *
-     * @param map JSON object.
-     * @param name name of the property.
-     * @return the float value associated with it, or -1.0 if not defined.
-     */
-    public static float getFloatValue(JSONObject map, String name) {
-    	Double d = (Double) map.get(name);
-
-    	return (d != null) ? d.floatValue() : -1.0f;
-    }
-
 }

--- a/client/src/main/java/org/apache/oozie/client/rest/JsonUtils.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/JsonUtils.java
@@ -65,5 +65,19 @@ public class JsonUtils {
         }
         return null;
     }
+    
+    /**
+     * Return a float value from a JSONObject.
+     * This is used only for getting job's progress value.
+     *
+     * @param map JSON object.
+     * @param name name of the property.
+     * @return the float value associated with it, or -1.0 if not defined.
+     */
+    public static float getFloatValue(JSONObject map, String name) {
+    	Double d = (Double) map.get(name);
+
+    	return (d != null) ? d.floatValue() : -1.0f;
+    }
 
 }

--- a/core/src/main/java/org/apache/oozie/WorkflowJobBean.java
+++ b/core/src/main/java/org/apache/oozie/WorkflowJobBean.java
@@ -146,6 +146,7 @@ public class WorkflowJobBean extends JsonWorkflowJob implements Writable {
         WritableUtils.writeStr(dataOutput, authToken);
         WritableUtils.writeStr(dataOutput, logToken);
         WritableUtils.writeStr(dataOutput, protoActionConf);
+        dataOutput.writeFloat(getProgress());
     }
 
     /**
@@ -186,6 +187,7 @@ public class WorkflowJobBean extends JsonWorkflowJob implements Writable {
         protoActionConf = WritableUtils.readStr(dataInput);
         setExternalId(getExternalId());
         setProtoActionConf(protoActionConf);
+        setProgress(dataInput.readFloat());
     }
 
     public String getAuthToken() {

--- a/core/src/main/java/org/apache/oozie/client/rest/JsonWorkflowJob.java
+++ b/core/src/main/java/org/apache/oozie/client/rest/JsonWorkflowJob.java
@@ -91,6 +91,9 @@ public class JsonWorkflowJob implements WorkflowJob, JsonBean {
     @Transient
     private List<? extends JsonWorkflowAction> actions;
 
+    @Transient
+    private float progress;
+
     public JsonWorkflowJob() {
         actions = new ArrayList<JsonWorkflowAction>();
     }
@@ -114,6 +117,7 @@ public class JsonWorkflowJob implements WorkflowJob, JsonBean {
         json.put(JsonTags.WORKFLOW_RUN, (long) getRun());
         json.put(JsonTags.WORKFLOW_CONSOLE_URL, getConsoleUrl());
         json.put(JsonTags.WORKFLOW_ACTIONS, JsonWorkflowAction.toJSONArray(actions));
+        json.put(JsonTags.WORKFLOW_PROGRESS, progress);
         json.put(JsonTags.TO_STRING, toString());
         return json;
     }
@@ -261,6 +265,14 @@ public class JsonWorkflowJob implements WorkflowJob, JsonBean {
     @SuppressWarnings("unchecked")
     public List<WorkflowAction> getActions() {
         return (List) actions;
+    }
+
+    public void setProgress(float p) {
+    	progress = p;
+    }
+
+    public float getProgress() {
+    	return progress;
     }
 
     public void setActions(List<? extends JsonWorkflowAction> nodes) {

--- a/core/src/main/java/org/apache/oozie/command/wf/JobCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/JobCommand.java
@@ -14,12 +14,19 @@
  */
 package org.apache.oozie.command.wf;
 
+import java.util.List;
+
 import org.apache.oozie.WorkflowJobBean;
+import org.apache.oozie.action.decision.DecisionActionExecutor;
+import org.apache.oozie.client.WorkflowAction;
+import org.apache.oozie.client.WorkflowJob;
+import org.apache.oozie.service.Services;
 import org.apache.oozie.store.StoreException;
 import org.apache.oozie.store.WorkflowStore;
 import org.apache.oozie.util.ParamChecker;
 import org.apache.oozie.util.XLog;
-import org.apache.oozie.service.Services;
+import org.apache.oozie.workflow.lite.LiteWorkflowApp;
+import org.apache.oozie.workflow.lite.LiteWorkflowInstance;
 
 /**
  * Command for loading a job information
@@ -52,6 +59,18 @@ public class JobCommand extends WorkflowCommand<WorkflowJobBean> {
     protected WorkflowJobBean call(WorkflowStore store) throws StoreException {
         WorkflowJobBean workflow = store.getWorkflowInfoWithActionsSubset(id, start, len);
         workflow.setConsoleUrl(getJobConsoleUrl(id));
+
+        // Estimate job progress
+        if (workflow.getStatus() == WorkflowJob.Status.PREP) {
+            workflow.setProgress(0.0f);
+        }
+        else if (workflow.getStatus() == WorkflowJob.Status.SUCCEEDED) {
+            workflow.setProgress(1.0f);
+        }
+        else {
+            workflow.setProgress(getJobProgress(workflow));
+        }
+
         return workflow;
     }
 
@@ -60,4 +79,32 @@ public class JobCommand extends WorkflowCommand<WorkflowJobBean> {
         return (consoleUrl != null) ? consoleUrl + jobId : null;
     }
 
+    /**
+     * Compute job progress that is defined as fraction of done actions. 
+     * 
+     * @param wf workflow job bean
+     * @return job progress
+     */
+    static float getJobProgress(WorkflowJobBean wf) {
+        LiteWorkflowInstance wfInstance = (LiteWorkflowInstance) wf.getWorkflowInstance();
+        LiteWorkflowApp wfApp = (LiteWorkflowApp) wfInstance.getApp();
+
+        int executionPathLengthEstimate = wfApp.getExecutionPathLengthEstimate();
+        if (executionPathLengthEstimate == 0) { // noop wf
+            return 1.0f;
+        }
+        List<WorkflowAction> actions = wf.getActions();
+        int doneActions = 0;
+        for (WorkflowAction action : actions) {
+            // Skip decision nodes, note start, kill, end, fork/join will not have action entry.
+            if (action.getType().equals(DecisionActionExecutor.ACTION_TYPE)) {
+                continue;
+            }
+            if (action.getStatus() == WorkflowAction.Status.OK || action.getStatus() == WorkflowAction.Status.DONE) {
+                doneActions++;
+            }
+        }
+
+        return (doneActions * 1.0f) / executionPathLengthEstimate;
+    }
 }

--- a/core/src/main/java/org/apache/oozie/command/wf/JobCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/JobCommand.java
@@ -90,26 +90,32 @@ public class JobCommand extends WorkflowCommand<WorkflowJobBean> {
         LiteWorkflowApp wfApp = (LiteWorkflowApp) wfInstance.getApp();
 
         int executionPathLengthEstimate = wfApp.getExecutionPathLengthEstimate();
+        float progress;
         if (executionPathLengthEstimate == 0) { // noop wf
-            return 1.0f;
+            progress = 1.0f;
         }
-        List<WorkflowAction> actions = wf.getActions();
-        int doneActions = 0;
-        for (WorkflowAction action : actions) {
-            // Skip decision nodes, note start, kill, end, fork/join will not have action entry.
-            if (action.getType().equals(DecisionActionExecutor.ACTION_TYPE)) {
-                continue;
+        else {
+            List<WorkflowAction> actions = wf.getActions();
+            int doneActions = 0;
+            for (WorkflowAction action : actions) {
+                // Skip decision nodes, note start, kill, end, fork/join will not have action entry.
+                if (action.getType().equals(DecisionActionExecutor.ACTION_TYPE)) {
+                    // noop
+                }
+                else {
+                    // Make progress if an action is in terminal state
+                    if (action.getStatus() == WorkflowAction.Status.OK
+                            || action.getStatus() == WorkflowAction.Status.ERROR
+                            || action.getStatus() == WorkflowAction.Status.FAILED
+                            || action.getStatus() == WorkflowAction.Status.KILLED) {
+                        doneActions++;
+                    }
+                }
             }
-            // Make progress if an action is in terminal state
-            if (action.getStatus() == WorkflowAction.Status.OK 
-                    || action.getStatus() == WorkflowAction.Status.DONE
-                    || action.getStatus() == WorkflowAction.Status.ERROR
-                    || action.getStatus() == WorkflowAction.Status.FAILED
-                    || action.getStatus() == WorkflowAction.Status.KILLED) {
-                doneActions++;
-            }
+
+            progress = (doneActions * 1.0f) / executionPathLengthEstimate;
         }
 
-        return (doneActions * 1.0f) / executionPathLengthEstimate;
+        return progress;
     }
 }

--- a/core/src/main/java/org/apache/oozie/command/wf/JobCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/JobCommand.java
@@ -100,7 +100,12 @@ public class JobCommand extends WorkflowCommand<WorkflowJobBean> {
             if (action.getType().equals(DecisionActionExecutor.ACTION_TYPE)) {
                 continue;
             }
-            if (action.getStatus() == WorkflowAction.Status.OK || action.getStatus() == WorkflowAction.Status.DONE) {
+            // Make progress if an action is in terminal state
+            if (action.getStatus() == WorkflowAction.Status.OK 
+                    || action.getStatus() == WorkflowAction.Status.DONE
+                    || action.getStatus() == WorkflowAction.Status.ERROR
+                    || action.getStatus() == WorkflowAction.Status.FAILED
+                    || action.getStatus() == WorkflowAction.Status.KILLED) {
                 doneActions++;
             }
         }

--- a/core/src/main/java/org/apache/oozie/command/wf/JobXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/wf/JobXCommand.java
@@ -14,8 +14,11 @@
  */
 package org.apache.oozie.command.wf;
 
+import java.util.List;
+
 import org.apache.oozie.ErrorCode;
 import org.apache.oozie.WorkflowJobBean;
+import org.apache.oozie.action.decision.DecisionActionExecutor;
 import org.apache.oozie.command.CommandException;
 import org.apache.oozie.command.PreconditionException;
 import org.apache.oozie.executor.jpa.JPAExecutorException;
@@ -23,6 +26,10 @@ import org.apache.oozie.executor.jpa.WorkflowInfoWithActionsSubsetGetJPAExecutor
 import org.apache.oozie.service.JPAService;
 import org.apache.oozie.service.Services;
 import org.apache.oozie.util.ParamChecker;
+import org.apache.oozie.workflow.lite.LiteWorkflowApp;
+import org.apache.oozie.workflow.lite.LiteWorkflowInstance;
+import org.apache.oozie.client.WorkflowAction;
+import org.apache.oozie.client.WorkflowJob;
 
 /**
  * This Xcommand is returning the workflow with action within the range.
@@ -63,6 +70,17 @@ public class JobXCommand extends WorkflowXCommand<WorkflowJobBean> {
                 throw new CommandException(ErrorCode.E0610, this.id);
             }
             this.workflow.setConsoleUrl(getJobConsoleUrl(id));
+        
+            // Estimate job progress
+            if (workflow.getStatus() == WorkflowJob.Status.PREP) {
+                workflow.setProgress(0.0f);
+            }
+            else if (workflow.getStatus() == WorkflowJob.Status.SUCCEEDED) {
+                workflow.setProgress(1.0f);
+            }
+            else {
+                workflow.setProgress(getJobProgress(workflow));
+            }
         }
         catch (JPAExecutorException ex) {
             throw new CommandException(ex);
@@ -111,5 +129,34 @@ public class JobXCommand extends WorkflowXCommand<WorkflowJobBean> {
      */
     @Override
     protected void verifyPrecondition() throws CommandException, PreconditionException {
+    }
+
+    /**
+     * Compute job progress that is defined as fraction of done actions. 
+     * 
+     * @param wf workflow job bean
+     * @return job progress
+     */
+    static float getJobProgress(WorkflowJobBean wf) {
+        LiteWorkflowInstance wfInstance = (LiteWorkflowInstance) wf.getWorkflowInstance();
+        LiteWorkflowApp wfApp = (LiteWorkflowApp) wfInstance.getApp();
+
+        int executionPathLengthEstimate = wfApp.getExecutionPathLengthEstimate();
+        if (executionPathLengthEstimate == 0) { // noop wf
+            return 1.0f;
+        }
+        List<WorkflowAction> actions = wf.getActions();
+        int doneActions = 0;
+        for (WorkflowAction action : actions) {
+            // Skip decision nodes, note start, kill, end, fork/join will not have action entry.
+            if (action.getType().equals(DecisionActionExecutor.ACTION_TYPE)) {
+                continue;
+            }
+            if (action.getStatus() == WorkflowAction.Status.OK || action.getStatus() == WorkflowAction.Status.DONE) {
+                doneActions++;
+            }
+        }
+
+        return (doneActions * 1.0f) / executionPathLengthEstimate;
     }
 }

--- a/core/src/main/java/org/apache/oozie/workflow/lite/LiteWorkflowApp.java
+++ b/core/src/main/java/org/apache/oozie/workflow/lite/LiteWorkflowApp.java
@@ -38,6 +38,7 @@ public class LiteWorkflowApp implements Writable, WorkflowApp {
     private String definition;
     private Map<String, NodeDef> nodesMap = new LinkedHashMap<String, NodeDef>();
     private boolean complete = false;
+    private int executionPathLengthEstimate = -1;
 
     LiteWorkflowApp() {
     }
@@ -122,6 +123,7 @@ public class LiteWorkflowApp implements Writable, WorkflowApp {
             dataOutput.writeUTF(n.getClass().getName());
             n.write(dataOutput);
         }
+        dataOutput.writeInt(executionPathLengthEstimate);
     }
 
     /**
@@ -176,6 +178,16 @@ public class LiteWorkflowApp implements Writable, WorkflowApp {
                 throw new IOException(e);
             }
         }
+
+        executionPathLengthEstimate = dataInput.readInt();
+    }
+    
+    public int getExecutionPathLengthEstimate() {
+        return executionPathLengthEstimate;
+    }
+
+    public void setExecutionPathLengthEstimate(int length) {
+        executionPathLengthEstimate = length;
     }
 
 }

--- a/core/src/main/java/org/apache/oozie/workflow/lite/LiteWorkflowAppParser.java
+++ b/core/src/main/java/org/apache/oozie/workflow/lite/LiteWorkflowAppParser.java
@@ -34,9 +34,13 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Class to parse and validate workflow xml
@@ -111,6 +115,9 @@ public class LiteWorkflowAppParser {
             Map<String, VisitStatus> traversed = new HashMap<String, VisitStatus>();
             traversed.put(app.getNode(StartNodeDef.START).getName(), VisitStatus.VISITING);
             validate(app, app.getNode(StartNodeDef.START), traversed);
+            
+            Set<String> reachableNodes = traversed.keySet();
+            setExecutionPathLengthEstimate(app, reachableNodes);
             return app;
         }
         catch (JDOMException ex) {
@@ -275,5 +282,163 @@ public class LiteWorkflowAppParser {
             validate(app, app.getNode(transition), traversed);
         }
         traversed.put(node.getName(), VisitStatus.VISITED);
+    }
+
+    /*
+     * Get source nodes (with no edges pointing to them) from a DAG;
+     */
+    List<String> getSourceNodes(Map<String, List<String>> DAG) {
+        Set<String> cloneNodes = new HashSet<String>();
+        for (String node : DAG.keySet()) {
+            cloneNodes.add(node);
+        }
+        
+        Iterator<String> iter = cloneNodes.iterator();
+        
+        Set<String> nonSourceNodes = new HashSet<String>();
+        while (iter.hasNext()) {
+            String name = iter.next();
+            List<String> edges = DAG.get(name);
+            for (String e : edges) {
+                nonSourceNodes.add(e);
+            }
+        }
+        
+        cloneNodes.removeAll(nonSourceNodes);
+        
+        return new ArrayList<String>(cloneNodes);
+    }
+    
+    /*
+     * Perform topological sort on a DAG;
+     */
+    @SuppressWarnings("unchecked")
+    private List<String> topologicalSort(Map<String, List<String>> DAG) {
+        Map<String, List<String>> clonedDAG = (Map<String, List<String>>)((HashMap<String, List<String>>)DAG).clone();
+        List<String> R = new ArrayList<String>();
+        clonedDAG.remove(StartNodeDef.START);
+        R.add(StartNodeDef.START);
+
+        while (clonedDAG.size() > 0) {
+            List<String> sourceNodes = getSourceNodes(clonedDAG);
+            R.addAll(sourceNodes);
+
+            for (String node : sourceNodes) {
+                clonedDAG.remove(node);
+            }
+        }
+
+        return R;
+    }
+
+    /*
+     * Check if a node is control node or dummy node.
+     */
+    private boolean isControlNode(NodeDef node) {
+        if (node instanceof StartNodeDef 
+                || node instanceof EndNodeDef
+                || node instanceof DecisionNodeDef
+                || node instanceof ForkNodeDef
+                || node instanceof JoinNodeDef
+                || node instanceof KillNodeDef) {
+            return true;
+        }
+        
+        return false;
+    }
+
+    /*
+     * Using dynamic programming to compute longest execution path of a DAG;
+     */
+    private int getLongestExecutionPathLength(LiteWorkflowApp app, Set<String> reachableNodes) {
+        Map<String, List<String>> DAG = new HashMap<String, List<String>>();
+        Collection<NodeDef> C = app.getNodeDefs();
+        Iterator<NodeDef> iterator = C.iterator();
+        while (iterator.hasNext()) {
+            NodeDef node = iterator.next();
+            if (reachableNodes.contains(node.getName())) { // only add reachable nodes from "start"
+                DAG.put(node.getName(), node.getTransitions());
+            }
+        }
+
+        List<String> topoSort = topologicalSort(DAG);
+        Map<String, Integer> length_to = new HashMap<String, Integer>();
+        // initialize
+        for (String node : topoSort) {
+            length_to.put(node, 0);
+        }
+
+        for (String node_v : topoSort) { 
+            List<String> nodes = DAG.get(node_v);
+            
+            for (String node_w : nodes) { // v -> w is an edge
+                int weight = isControlNode(app.getNode(node_w))? 0 : 1; 
+                if (length_to.get(node_w) <= length_to.get(node_v) + weight) {
+                    length_to.put(node_w, length_to.get(node_v) + weight);
+                }
+            }
+        }
+
+        int maxLength = -1;
+        Set<String> nodes = length_to.keySet();
+        for (String node : nodes) {
+            if (length_to.get(node) > maxLength) {
+                maxLength = length_to.get(node);
+            }
+        }
+
+        return maxLength;
+    }
+
+    /*
+     * Check if a wf app contains fork/join actions.
+     */
+    private boolean containFork(LiteWorkflowApp app, Set<String> reachableNodeNames) {
+        for (String nodeName : reachableNodeNames) {
+            if (app.getNode(nodeName) instanceof ForkNodeDef) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /*
+     * Evaluate total count of work actions in a wf app.
+     */
+    private int getTotalActionCount(LiteWorkflowApp app, Set<String> reachableNodeNames) {
+        int cnt = 0;
+        for (String nodeName : reachableNodeNames) {
+            if (!isControlNode(app.getNode(nodeName))) {
+                cnt ++;
+            }
+        }
+
+        return cnt;
+    }
+
+    /*
+     * Estimate a wf app's execution path length. This is for estimating the app's progress.
+     * 
+     * @param app wf app
+     * @param reachableNodeNames names of nodes that are reachable from "start". 
+     *        This is to save one extra traversal of the DAG since we already traversed it previously,
+     *        so reuse that result.
+     */
+    private void setExecutionPathLengthEstimate(LiteWorkflowApp app, Set<String> reachableNodeNames) {
+        int length = -1;
+
+        // TODO
+        // if DAG contain fork/join, we simply check total number of work actions.
+        // This can be improved in future.
+        if (containFork(app, reachableNodeNames) == true) {
+            length = getTotalActionCount(app, reachableNodeNames);
+        }
+        // Otherwise (it can contain decision node), we use longest possible execution path.
+        else {
+            length = getLongestExecutionPathLength(app, reachableNodeNames);
+        }
+
+        app.setExecutionPathLengthEstimate(length);
     }
 }

--- a/core/src/test/java/org/apache/oozie/command/wf/TestWorkflowProgress.java
+++ b/core/src/test/java/org/apache/oozie/command/wf/TestWorkflowProgress.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+package org.apache.oozie.command.wf;
+
+import org.apache.oozie.test.XFsTestCase;
+import org.apache.oozie.local.LocalOozie;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.oozie.client.OozieClient;
+import org.apache.oozie.client.WorkflowJob;
+
+import java.io.File;
+import java.io.Writer;
+import java.io.OutputStreamWriter;
+import java.util.Properties;
+
+public class TestWorkflowProgress extends XFsTestCase {
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        setSystemProperty("oozielastmod.log", "/tmp/oozielastmod.log");
+    }
+
+    public void testProgress() throws Exception {
+        FileSystem fs = getFileSystem();
+        Path appPath = new Path(getFsTestCaseDir(), "app");
+        fs.mkdirs(appPath);
+        Writer writer = new OutputStreamWriter(fs.create(new Path(appPath, "workflow.xml")));
+        String wfApp = "<workflow-app xmlns='uri:oozie:workflow:0.1' name='test-wf'>" + "    <start to='end'/>"
+        + "    <end name='end'/>" + "</workflow-app>";
+        writer.write(wfApp);
+        writer.close();
+        
+        try {
+            LocalOozie.start();
+            final OozieClient wc = LocalOozie.getClient();
+            Properties conf = wc.createConfiguration();
+            conf.setProperty(OozieClient.APP_PATH, appPath.toString() + File.separator + "workflow.xml");
+            conf.setProperty(OozieClient.USER_NAME, getTestUser());
+            conf.setProperty(OozieClient.GROUP_NAME, getTestGroup());
+            injectKerberosInfo(conf);
+
+            final String jobId = wc.submit(conf);
+            WorkflowJob wf = wc.getJobInfo(jobId);
+            float p = wf.getProgress();
+            assertEquals(p, 0.0f);
+
+            wc.start(jobId);
+            wf = wc.getJobInfo(jobId);
+            assertEquals(p, 0.0f);
+            waitFor(600000, new Predicate() {
+                public boolean evaluate() throws Exception {
+                    WorkflowJob wf = wc.getJobInfo(jobId);
+                    return wf.getStatus() == WorkflowJob.Status.SUCCEEDED;
+                }
+            });
+
+            wf = wc.getJobInfo(jobId);
+            p = wf.getProgress();
+            assertEquals(p, 1.0f);
+        }
+        finally {
+            LocalOozie.stop();
+        }
+    }
+}

--- a/core/src/test/java/org/apache/oozie/service/TestLiteWorkflowAppService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestLiteWorkflowAppService.java
@@ -480,5 +480,156 @@ public class TestLiteWorkflowAppService extends XTestCase {
             services.destroy();
         }
     }
+    
+    // test a simple normal wf
+    public void testExecutionPathEstimate1() throws Exception {
+        Services services = new Services();
+        try {
+            services.init();
+            WorkflowAppService wps = services.get(WorkflowAppService.class);
 
+            Reader reader = IOUtils.getResourceAsReader("wf-progress-test1.xml", -1);
+            Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
+            IOUtils.copyCharStream(reader, writer);
+
+            Configuration jobConf = new XConfiguration();
+            jobConf.set(OozieClient.APP_PATH, "file://" + getTestCaseDir() + File.separator + "workflow.xml");
+            jobConf.set(OozieClient.USER_NAME, getTestUser());
+            jobConf.set(OozieClient.GROUP_NAME, "group");
+            injectKerberosInfo(jobConf);
+
+            LiteWorkflowApp app = (LiteWorkflowApp) wps.parseDef(jobConf, "authToken");
+            
+            int length = app.getExecutionPathLengthEstimate();
+            assertEquals(2, length);
+        }
+        finally {
+            services.destroy();
+        }
+    }
+    
+    // test orphan nodes
+    public void testExecutionPathEstimate2() throws Exception {
+        Services services = new Services();
+        try {
+            services.init();
+            WorkflowAppService wps = services.get(WorkflowAppService.class);
+
+            Reader reader = IOUtils.getResourceAsReader("wf-progress-test2.xml", -1);
+            Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
+            IOUtils.copyCharStream(reader, writer);
+
+            Configuration jobConf = new XConfiguration();
+            jobConf.set(OozieClient.APP_PATH, "file://" + getTestCaseDir() + File.separator + "workflow.xml");
+            jobConf.set(OozieClient.USER_NAME, getTestUser());
+            jobConf.set(OozieClient.GROUP_NAME, "group");
+
+            LiteWorkflowApp app = (LiteWorkflowApp) wps.parseDef(jobConf, "authToken");
+            int length = app.getExecutionPathLengthEstimate();
+            assertEquals(5, length);
+        }
+        finally {
+            services.destroy();
+        }
+    }
+    
+    // test orphan nodes
+    public void testExecutionPathEstimate3() throws Exception {
+        Services services = new Services();
+        try {
+            services.init();
+            WorkflowAppService wps = services.get(WorkflowAppService.class);
+
+            Reader reader = IOUtils.getResourceAsReader("wf-progress-test3.xml", -1);
+            Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
+            IOUtils.copyCharStream(reader, writer);
+
+            Configuration jobConf = new XConfiguration();
+            jobConf.set(OozieClient.APP_PATH, "file://" + getTestCaseDir() + File.separator + "workflow.xml");
+            jobConf.set(OozieClient.USER_NAME, getTestUser());
+            jobConf.set(OozieClient.GROUP_NAME, "group");
+
+            LiteWorkflowApp app = (LiteWorkflowApp) wps.parseDef(jobConf, "authToken");
+            int length = app.getExecutionPathLengthEstimate();
+            assertEquals(5, length);
+        }
+        finally {
+            services.destroy();
+        }
+    }
+    
+    // test recursive decision
+    public void testExecutionPathEstimate4() throws Exception {
+        Services services = new Services();
+        try {
+            services.init();
+            WorkflowAppService wps = services.get(WorkflowAppService.class);
+
+            Reader reader = IOUtils.getResourceAsReader("wf-progress-test4.xml", -1);
+            Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
+            IOUtils.copyCharStream(reader, writer);
+
+            Configuration jobConf = new XConfiguration();
+            jobConf.set(OozieClient.APP_PATH, "file://" + getTestCaseDir() + File.separator + "workflow.xml");
+            jobConf.set(OozieClient.USER_NAME, getTestUser());
+            jobConf.set(OozieClient.GROUP_NAME, "group");
+
+            LiteWorkflowApp app = (LiteWorkflowApp) wps.parseDef(jobConf, "authToken");
+            int length = app.getExecutionPathLengthEstimate();
+            assertEquals(6, length);
+        }
+        finally {
+            services.destroy();
+        }
+    }
+    
+    // test longest execution path via <error>
+    public void testExecutionPathEstimate5() throws Exception {
+        Services services = new Services();
+        try {
+            services.init();
+            WorkflowAppService wps = services.get(WorkflowAppService.class);
+
+            Reader reader = IOUtils.getResourceAsReader("wf-progress-test5.xml", -1);
+            Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
+            IOUtils.copyCharStream(reader, writer);
+
+            Configuration jobConf = new XConfiguration();
+            jobConf.set(OozieClient.APP_PATH, "file://" + getTestCaseDir() + File.separator + "workflow.xml");
+            jobConf.set(OozieClient.USER_NAME, getTestUser());
+            jobConf.set(OozieClient.GROUP_NAME, "group");
+
+            LiteWorkflowApp app = (LiteWorkflowApp) wps.parseDef(jobConf, "authToken");
+            int length = app.getExecutionPathLengthEstimate();
+            assertEquals(6, length);
+        }
+        finally {
+            services.destroy();
+        }
+    }
+
+    // test fork
+    public void testExecutionPathEstimate6() throws Exception {
+        Services services = new Services();
+        try {
+            services.init();
+            WorkflowAppService wps = services.get(WorkflowAppService.class);
+
+            Reader reader = IOUtils.getResourceAsReader("wf-progress-test6.xml", -1);
+            Writer writer = new FileWriter(getTestCaseDir() + "/workflow.xml");
+            IOUtils.copyCharStream(reader, writer);
+
+            Configuration jobConf = new XConfiguration();
+            jobConf.set(OozieClient.APP_PATH, "file://" + getTestCaseDir() + File.separator + "workflow.xml");
+            jobConf.set(OozieClient.USER_NAME, getTestUser());
+            jobConf.set(OozieClient.GROUP_NAME, "group");
+
+            LiteWorkflowApp app = (LiteWorkflowApp) wps.parseDef(jobConf, "authToken");
+            int length = app.getExecutionPathLengthEstimate();
+            assertEquals(7, length);
+        }
+        finally {
+            services.destroy();
+        }
+    }
 }

--- a/core/src/test/resources/wf-progress-test1.xml
+++ b/core/src/test/resources/wf-progress-test1.xml
@@ -1,0 +1,183 @@
+<!--
+  Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<workflow-app xmlns="uri:oozie:workflow:0.1" name="test-wf">
+    <start to="decision_1"/>
+    <decision name="decision_1">
+        <switch>
+            <case to="mr1">true</case>
+            <case to="mr2">false</case>
+            <default to="mr3"/>
+        </switch>
+    </decision>
+    <kill name="kill">
+        <message>kill</message>
+    </kill>
+
+    <action name="mr1">
+        <map-reduce>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <streaming>
+                <mapper>/mycat.sh</mapper>
+                <reducer>/mywc.sh</reducer>
+            </streaming>
+            <job-xml>/tmp</job-xml>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <file>/tmp</file>
+            <archive>/tmp</archive>
+        </map-reduce>
+        <ok to="end"/>
+        <error to="kill"/>
+    </action>
+    
+    <action name="mr2">
+        <map-reduce>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <streaming>
+                <mapper>/mycat.sh</mapper>
+                <reducer>/mywc.sh</reducer>
+            </streaming>
+            <job-xml>/tmp</job-xml>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <file>/tmp</file>
+            <archive>/tmp</archive>
+        </map-reduce>
+        <ok to="end"/>
+        <error to="kill"/>
+    </action>
+    
+    <action name="mr3">
+        <map-reduce>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <streaming>
+                <mapper>/mycat.sh</mapper>
+                <reducer>/mywc.sh</reducer>
+            </streaming>
+            <job-xml>/tmp</job-xml>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <file>/tmp</file>
+            <archive>/tmp</archive>
+        </map-reduce>
+        <ok to="pig1"/>
+        <error to="kill"/>
+    </action>
+
+    <action name="pig1">
+        <pig>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <script>/tmp</script>
+            <param>x</param>
+            <file>/tmp</file>
+            <file>/tmp</file>
+        </pig>
+        <ok to="end"/>
+        <error to="kill"/>
+    </action>
+
+    <action name="fs1">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs2"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs2">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs3"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs3">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs4"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs4">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>    
+
+    <end name="end"/>
+    
+
+    
+    
+    
+</workflow-app>

--- a/core/src/test/resources/wf-progress-test2.xml
+++ b/core/src/test/resources/wf-progress-test2.xml
@@ -1,0 +1,64 @@
+<!--
+  Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<workflow-app xmlns="uri:oozie:workflow:0.1" name="test-wf">
+    <start to="fs1"/>
+    <kill name="kill">
+        <message>kill</message>
+    </kill>
+
+    <action name="fs1">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs2"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs2">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs3"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs3">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs4"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="fs4">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs5"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs5">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>    
+
+    <end name="end"/>
+
+    
+</workflow-app>

--- a/core/src/test/resources/wf-progress-test3.xml
+++ b/core/src/test/resources/wf-progress-test3.xml
@@ -1,0 +1,112 @@
+<!--
+  Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<workflow-app xmlns="uri:oozie:workflow:0.1" name="test-wf">
+    <start to="fs1"/>
+    <kill name="kill">
+        <message>kill</message>
+    </kill>
+
+    <action name="fs1">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs2"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs2">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs3"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs3">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs4"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="fs4">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs5"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs5">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>   
+    
+    <action name="fs11">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs12"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs12">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs13"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs13">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs14"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="fs14">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs15"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs15">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs16"/>
+		<error to="kill"/>
+    </action>    
+    
+    <action name="fs16">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>  
+
+    <end name="end"/>
+
+    
+</workflow-app>

--- a/core/src/test/resources/wf-progress-test4.xml
+++ b/core/src/test/resources/wf-progress-test4.xml
@@ -1,0 +1,151 @@
+<!--
+  Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<workflow-app xmlns="uri:oozie:workflow:0.1" name="test-wf">
+    <start to="f1"/>
+    <kill name="kill">
+        <message>kill</message>
+    </kill>
+
+    <action name="f1">
+    	<fs>
+			<delete path="/tmp/"/>
+		</fs>
+		<ok to="decision1"/>
+		<error to="kill"/>
+    </action>
+    
+    <decision name="decision1">
+        <switch>
+            <case to="f2">true</case>
+            <case to="f3">false</case>
+            <default to="f4"/>
+        </switch>
+    </decision>
+    
+    <action name="f2">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f5"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f5">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>    
+    
+    <action name="f3">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="f4">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="decision2"/>
+		<error to="kill"/>
+    </action>
+    
+    <decision name="decision2">
+        <switch>
+            <case to="decision3">true</case>
+            <case to="f6">false</case>
+            <default to="f7"/>
+        </switch>
+    </decision>
+
+    <decision name="decision3">
+        <switch>
+            <case to="f8">true</case>
+            <case to="f9">false</case>
+            <default to="f10"/>
+        </switch>
+    </decision>
+    
+    <action name="f6">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+    
+        <action name="f7">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>      
+    
+    <action name="f8">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f9">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f11"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f10">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="f11">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f12"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f12">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f13"/>
+		<error to="kill"/>
+    </action>    
+    
+    <action name="f13">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>    
+    
+    <end name="end"/>
+    
+</workflow-app>

--- a/core/src/test/resources/wf-progress-test5.xml
+++ b/core/src/test/resources/wf-progress-test5.xml
@@ -1,0 +1,151 @@
+<!--
+  Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<workflow-app xmlns="uri:oozie:workflow:0.1" name="test-wf">
+    <start to="f1"/>
+    <kill name="kill">
+        <message>kill</message>
+    </kill>
+
+    <action name="f1">
+    	<fs>
+			<delete path="/tmp/"/>
+		</fs>
+		<ok to="end"/>
+		<error to="decision1"/>
+    </action>
+    
+    <decision name="decision1">
+        <switch>
+            <case to="f2">true</case>
+            <case to="f3">false</case>
+            <default to="f4"/>
+        </switch>
+    </decision>
+    
+    <action name="f2">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f5"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f5">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>    
+    
+    <action name="f3">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="f4">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="decision2"/>
+		<error to="kill"/>
+    </action>
+    
+    <decision name="decision2">
+        <switch>
+            <case to="decision3">true</case>
+            <case to="f6">false</case>
+            <default to="f7"/>
+        </switch>
+    </decision>
+
+    <decision name="decision3">
+        <switch>
+            <case to="f8">true</case>
+            <case to="f9">false</case>
+            <default to="f10"/>
+        </switch>
+    </decision>
+    
+    <action name="f6">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+    
+        <action name="f7">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>      
+    
+    <action name="f8">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f9">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f11"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f10">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="f11">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f12"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f12">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f13"/>
+		<error to="kill"/>
+    </action>    
+    
+    <action name="f13">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>    
+    
+    <end name="end"/>
+    
+</workflow-app>

--- a/core/src/test/resources/wf-progress-test6.xml
+++ b/core/src/test/resources/wf-progress-test6.xml
@@ -1,0 +1,214 @@
+<!--
+  Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<workflow-app xmlns="uri:oozie:workflow:0.1" name="test-wf">
+    <start to="decision_1"/>
+    <decision name="decision_1">
+        <switch>
+            <case to="mr1">true</case>
+            <case to="mr2">false</case>
+            <default to="mr3"/>
+        </switch>
+    </decision>
+    <kill name="kill">
+        <message>kill</message>
+    </kill>
+
+    <action name="mr1">
+        <map-reduce>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <streaming>
+                <mapper>/mycat.sh</mapper>
+                <reducer>/mywc.sh</reducer>
+            </streaming>
+            <job-xml>/tmp</job-xml>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <file>/tmp</file>
+            <archive>/tmp</archive>
+        </map-reduce>
+        <ok to="fork1"/>
+        <error to="kill"/>
+    </action>
+    
+    <fork name="fork1">
+        <path start="f1"/>
+        <path start="f2"/>
+    </fork>
+    
+    <action name="f1">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="f3"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="f2">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="join1"/>
+		<error to="kill"/>
+    </action>
+
+    <action name="f3">
+    	<fs>
+			<delete path="/tmp"/>
+		</fs>
+		<ok to="join1"/>
+		<error to="kill"/>
+    </action>
+    
+    <join name="join1" to="end"/>
+    
+    <action name="mr2">
+        <map-reduce>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <streaming>
+                <mapper>/mycat.sh</mapper>
+                <reducer>/mywc.sh</reducer>
+            </streaming>
+            <job-xml>/tmp</job-xml>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <file>/tmp</file>
+            <archive>/tmp</archive>
+        </map-reduce>
+        <ok to="end"/>
+        <error to="kill"/>
+    </action>
+    
+    <action name="mr3">
+        <map-reduce>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <streaming>
+                <mapper>/mycat.sh</mapper>
+                <reducer>/mywc.sh</reducer>
+            </streaming>
+            <job-xml>/tmp</job-xml>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <file>/tmp</file>
+            <archive>/tmp</archive>
+        </map-reduce>
+        <ok to="pig1"/>
+        <error to="kill"/>
+    </action>
+
+    <action name="pig1">
+        <pig>
+            <job-tracker>foo</job-tracker>
+            <name-node>bar</name-node>
+            <prepare>
+                <delete path="/tmp"/>
+                <mkdir path="/tmp"/>
+            </prepare>
+            <configuration>
+                <property>
+                    <name>a</name>
+                    <value>A</value>
+                </property>
+                <property>
+                    <name>b</name>
+                    <value>B</value>
+                </property>
+            </configuration>
+            <script>/tmp</script>
+            <param>x</param>
+            <file>/tmp</file>
+            <file>/tmp</file>
+        </pig>
+        <ok to="end"/>
+        <error to="kill"/>
+    </action>
+
+    <action name="fs1">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs2"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs2">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs3"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs3">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="fs4"/>
+		<error to="kill"/>
+    </action>
+    
+    <action name="fs4">
+    	<fs>
+			<delete path="/tmp/1"/>
+		</fs>
+		<ok to="end"/>
+		<error to="kill"/>
+    </action>    
+
+    <end name="end"/>
+    
+
+    
+    
+    
+</workflow-app>

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.1.0 release
 
+OOZIE-130 build workflow progress information in Oozie
 OOZIE-124 Update documentation for job-type in WS API
 OOZIE-81 Add an email action to Oozie
 OOZIE-113 merge changes for OOZIE-101 to ActionEndXCommand 


### PR DESCRIPTION
I relaxed chain type in my patch:

1) if the wf dag does not contain fork/join, i evaluate the longest possible execution path.

2) if the dag contains fork/join, I simply count total number of work actions (excluding control nodes and dummy nodes like "start", "end", "kill").
