### PR TITLE
OOZIE-5-7 Log retrieval for large no. of actions, Individual action log

### DIFF
--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -721,6 +721,9 @@ public class OozieCLI {
                     }
                    	wc.getJobLog(commandLine.getOptionValue(LOG_OPTION),logRetrievalType,logRetrievalScope,System.out);
             	}
+		else {
+                    System.out.println(wc.getJobLog(commandLine.getOptionValue(LOG_OPTION)));			
+		}
             }
             else if (options.contains(DEFINITION_OPTION)) {
                 System.out.println(wc.getJobDefinition(commandLine.getOptionValue(DEFINITION_OPTION)));

--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -16,9 +16,6 @@ package org.apache.oozie.cli;
 
 import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
-
-
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -465,7 +462,6 @@ public class OozieCLI {
         }
         else {
             File file = new File(configFile);
-            System.out.println(file.getCanonicalPath());
             if (!file.exists()) {
                 throw new IOException("configuration file [" + configFile + "] not found");
             }
@@ -569,11 +565,9 @@ public class OozieCLI {
         }
 
         try {
-        	
             if (options.contains(SUBMIT_OPTION)) {
                 System.out.println(JOB_ID_PREFIX + wc.submit(getConfiguration(commandLine)));
             }
-            
             else if (options.contains(START_OPTION)) {
                 wc.start(commandLine.getOptionValue(START_OPTION));
             }
@@ -709,7 +703,6 @@ public class OozieCLI {
                             .contains(LOCAL_TIME_OPTION), options.contains(VERBOSE_OPTION));
                 }
             }
-            
             else if (options.contains(LOG_OPTION)) {            	
             	if (commandLine.getOptionValue(LOG_OPTION).contains("-C")) {
             		String logRetrievalScope = null;
@@ -729,7 +722,6 @@ public class OozieCLI {
                    	wc.getJobLog(commandLine.getOptionValue(LOG_OPTION),logRetrievalType,logRetrievalScope,System.out);
             	}
             }
-            
             else if (options.contains(DEFINITION_OPTION)) {
                 System.out.println(wc.getJobDefinition(commandLine.getOptionValue(DEFINITION_OPTION)));
             }
@@ -749,7 +741,6 @@ public class OozieCLI {
                             + "] doesn't end with either C or W or B");
                 }
             }
-        
         }
         catch (OozieClientException ex) {
             throw new OozieCLIException(ex.toString(), ex);

--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -14,11 +14,17 @@
  */
 package org.apache.oozie.cli;
 
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+
+
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -94,6 +100,8 @@ public class OozieCLI {
     public static final String RERUN_OPTION = "rerun";
     public static final String INFO_OPTION = "info";
     public static final String LOG_OPTION = "log";
+    public static final String LOG_ACTION_OPTION = "action";
+    public static final String LOG_DATE_OPTION = "date";
     public static final String DEFINITION_OPTION = "definition";
     public static final String CONFIG_CONTENT_OPTION = "configcontent";
 
@@ -140,8 +148,8 @@ public class OozieCLI {
      *
      * @param args options and arguments for the Oozie CLI.
      */
-    public static void main(String[] args) {
-        System.exit(new OozieCLI().run(args));
+    public static void main(String[] args) throws IOException{
+    	System.exit(new OozieCLI().run(args));
     }
 
     /**
@@ -199,6 +207,8 @@ public class OozieCLI {
         Option len = new Option(LEN_OPTION, true, "number of actions (default TOTAL ACTIONS, requires -info)");
         Option localtime = new Option(LOCAL_TIME_OPTION, false, "use local time (default GMT)");
         Option log = new Option(LOG_OPTION, true, "job log");
+        Option log_action = new Option(LOG_ACTION_OPTION, true,"coordinator log retrieval on action ids (requires -log)");
+        Option log_date = new Option(LOG_DATE_OPTION, true,"coordinator log retrieval on action dates (requires -log)");
         Option definition = new Option(DEFINITION_OPTION, true, "job definition");
         Option config_content = new Option(CONFIG_CONTENT_OPTION, true, "job configuration");
         Option verbose = new Option(VERBOSE_OPTION, false, "verbose mode");
@@ -242,6 +252,8 @@ public class OozieCLI {
         jobOptions.addOption(rerun_coord);
         jobOptions.addOption(rerun_refresh);
         jobOptions.addOption(rerun_nocleanup);
+        jobOptions.addOption(log_action);
+        jobOptions.addOption(log_date);
         jobOptions.addOptionGroup(actions);
         return jobOptions;
     }
@@ -453,6 +465,7 @@ public class OozieCLI {
         }
         else {
             File file = new File(configFile);
+            System.out.println(file.getCanonicalPath());
             if (!file.exists()) {
                 throw new IOException("configuration file [" + configFile + "] not found");
             }
@@ -556,9 +569,11 @@ public class OozieCLI {
         }
 
         try {
+        	
             if (options.contains(SUBMIT_OPTION)) {
                 System.out.println(JOB_ID_PREFIX + wc.submit(getConfiguration(commandLine)));
             }
+            
             else if (options.contains(START_OPTION)) {
                 wc.start(commandLine.getOptionValue(START_OPTION));
             }
@@ -694,9 +709,27 @@ public class OozieCLI {
                             .contains(LOCAL_TIME_OPTION), options.contains(VERBOSE_OPTION));
                 }
             }
-            else if (options.contains(LOG_OPTION)) {
-                System.out.println(wc.getJobLog(commandLine.getOptionValue(LOG_OPTION)));
+            
+            else if (options.contains(LOG_OPTION)) {            	
+            	if (commandLine.getOptionValue(LOG_OPTION).contains("-C")) {
+            		String logRetrievalScope = null;
+                    String logRetrievalType = null;
+                    if (options.contains(LOG_DATE_OPTION) && options.contains(LOG_ACTION_OPTION)) {
+                        throw new OozieCLIException("Invalid options provided for log retrieval: either " + LOG_DATE_OPTION
+                                + " or " + LOG_ACTION_OPTION + " is expected. Do not use both at the same time.");
+                    }
+                    if (options.contains(LOG_DATE_OPTION)) {
+                    	logRetrievalType = RestConstants.JOB_LOG_DATE;
+                        logRetrievalScope = commandLine.getOptionValue(LOG_DATE_OPTION);
+                    }
+                    else if (options.contains(LOG_ACTION_OPTION)) {
+                    	logRetrievalType = RestConstants.JOB_LOG_ACTION;
+                        logRetrievalScope = commandLine.getOptionValue(LOG_ACTION_OPTION);
+                    }
+                   	wc.getJobLog(commandLine.getOptionValue(LOG_OPTION),logRetrievalType,logRetrievalScope,System.out);
+            	}
             }
+            
             else if (options.contains(DEFINITION_OPTION)) {
                 System.out.println(wc.getJobDefinition(commandLine.getOptionValue(DEFINITION_OPTION)));
             }
@@ -716,6 +749,7 @@ public class OozieCLI {
                             + "] doesn't end with either C or W or B");
                 }
             }
+        
         }
         catch (OozieClientException ex) {
             throw new OozieCLIException(ex.toString(), ex);
@@ -1187,8 +1221,6 @@ public class OozieCLI {
                 List<StreamSource> sources = new ArrayList<StreamSource>();
                 sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
                         "oozie-workflow-0.1.xsd")));
-                sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
-                        "email-action-0.1.xsd")));
                 SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
                 Schema schema = factory.newSchema(sources.toArray(new StreamSource[sources.size()]));
                 Validator validator = schema.newValidator();

--- a/client/src/main/java/org/apache/oozie/client/rest/RestConstants.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/RestConstants.java
@@ -87,6 +87,14 @@ public interface RestConstants {
     public static final String JOB_COORD_RERUN_REFRESH_PARAM = "refresh";
 
     public static final String JOB_COORD_RERUN_NOCLEANUP_PARAM = "nocleanup";
+    
+    public static final String JOB_LOG_DATE = "date";
+
+    public static final String JOB_LOG_ACTION = "action";
+    
+    public static final String JOB_LOG_SCOPE_PARAM = "scope";
+    
+    public static final String JOB_LOG_TYPE_PARAM = "type";
 
     public static final String JOBS_FILTER_PARAM = "filter";
 

--- a/core/src/main/java/org/apache/oozie/BaseEngine.java
+++ b/core/src/main/java/org/apache/oozie/BaseEngine.java
@@ -193,7 +193,7 @@ public abstract class BaseEngine {
      * jobId.
      */
     public abstract void streamLog(String jobId, Writer writer) throws IOException, BaseEngineException;
-
+    
     /**
      * Return the workflow Job ID for an external ID. <p/> This is reverse lookup for recovery purposes.
      *

--- a/core/src/main/java/org/apache/oozie/service/XLogService.java
+++ b/core/src/main/java/org/apache/oozie/service/XLogService.java
@@ -23,7 +23,9 @@ import org.apache.oozie.util.XLog;
 import org.apache.oozie.util.XLogStreamer;
 import org.apache.oozie.util.XConfiguration;
 import org.apache.oozie.BuildInfo;
+import org.apache.oozie.CoordinatorEngine;
 import org.apache.oozie.ErrorCode;
+import org.apache.openjpa.lib.log.Log;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.File;

--- a/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
+++ b/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
@@ -29,6 +29,7 @@ import org.apache.oozie.CoordinatorActionBean;
 import org.apache.oozie.CoordinatorActionInfo;
 import org.apache.oozie.CoordinatorEngine;
 import org.apache.oozie.CoordinatorEngineException;
+import org.apache.oozie.command.CommandException;
 import org.apache.oozie.DagEngine;
 import org.apache.oozie.DagEngineException;
 import org.apache.oozie.ErrorCode;
@@ -47,7 +48,7 @@ import org.json.simple.JSONObject;
 public class V1JobServlet extends BaseJobServlet {
 
     private static final String INSTRUMENTATION_NAME = "v1job";
-
+    
     public V1JobServlet() {
         super(INSTRUMENTATION_NAME);
     }
@@ -886,12 +887,16 @@ public class V1JobServlet extends BaseJobServlet {
                 getUser(request), getAuthToken(request));
 
         String jobId = getResourceName(request);
-
+        String logRetrievalScope = request.getParameter(RestConstants.JOB_LOG_SCOPE_PARAM);
+        String logRetrievalType = request.getParameter(RestConstants.JOB_LOG_TYPE_PARAM);
         try {
-            coordEngine.streamLog(jobId, response.getWriter());
+            coordEngine.streamLog(jobId,logRetrievalScope,logRetrievalType,response.getWriter());
         }
         catch (BaseEngineException ex) {
             throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
+        }
+        catch (CommandException ex) {
+        	throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
         }
     }
 }

--- a/core/src/main/java/org/apache/oozie/util/XLogReader.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogReader.java
@@ -14,6 +14,7 @@
  */
 package org.apache.oozie.util;
 
+import org.apache.oozie.service.XLogService; 
 import org.apache.oozie.util.XLogStreamer;
 
 import java.util.ArrayList;

--- a/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.*;
-
 import org.apache.oozie.service.XLogService;
 import org.mortbay.log.Log;
 
@@ -39,7 +38,7 @@ import org.mortbay.log.Log;
  */
 public class XLogStreamer {
 
-	/**
+    /**
      * Filter that will construct the regular expression that will be used to filter the log statement. And also checks
      * if the given log message go through the filter. Filters that can be used are logLevel(Multi values separated by
      * "|") jobId appName actionId token

--- a/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
@@ -20,20 +20,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.*;
+
+import org.apache.oozie.service.XLogService;
+import org.mortbay.log.Log;
 
 /**
  * XLogStreamer streams the given log file to logWriter after applying the given filter.
  */
 public class XLogStreamer {
 
-    /**
+	/**
      * Filter that will construct the regular expression that will be used to filter the log statement. And also checks
      * if the given log message go through the filter. Filters that can be used are logLevel(Multi values separated by
      * "|") jobId appName actionId token
@@ -143,7 +149,7 @@ public class XLogStreamer {
          * Constructs the regular expression according to the filter and assigns it to fileterPattarn. ".*" will be
          * assigned if no filters are set.
          */
-        public void constructPattern() {
+        public void constructPattern() { 
             if (noFilter && logLevels == null) {
                 filterPattern = Pattern.compile(ALLOW_ALL_REGEX);
                 return;
@@ -155,6 +161,22 @@ public class XLogStreamer {
             else {
                 sb.append("(.* - ");
                 for (int i = 0; i < parameters.size(); i++) {
+                    if(parameters.get(i).equals("ACTION"))
+                    {
+                    	String[] actionsList = filterParams.get(parameters.get(i)).split(",");
+                        sb.append("(");
+                    	
+                        for(int counter=0 ; counter<actionsList.length ; counter++)
+                    	{
+                    		if(counter!=0)
+                    			sb.append("|");
+                            sb.append("ACTION" + "\\[");
+                            sb.append(actionsList[counter] + "\\]");
+                    	}
+                    	
+                    	sb.append(") ");
+                    	continue;
+                    }
                     sb.append(parameters.get(i) + "\\[");
                     sb.append(filterParams.get(parameters.get(i)) + "\\] ");
                 }
@@ -162,7 +184,7 @@ public class XLogStreamer {
             }
             filterPattern = Pattern.compile(sb.toString());
         }
-
+        
         public static void reset() {
             parameters.clear();
         }
@@ -196,6 +218,10 @@ public class XLogStreamer {
     public void streamLog(Date startTime, Date endTime) throws IOException {
         long startTimeMillis = 0;
         long endTimeMillis;
+        String fileName;
+        InputStream ifs;
+        XLogReader logReader;
+        
         if (startTime != null) {
             startTimeMillis = startTime.getTime();
         }
@@ -208,9 +234,9 @@ public class XLogStreamer {
         File dir = new File(logPath);
         ArrayList<FileInfo> fileList = getFileList(dir, startTimeMillis, endTimeMillis, logRotation, logFile);
         for (int i = 0; i < fileList.size(); i++) {
-            InputStream ifs;
+        	fileName = fileList.get(i).getFileName();
             ifs = new FileInputStream(fileList.get(i).getFileName());
-            XLogReader logReader = new XLogReader(ifs, logFilter, logWriter);
+            logReader = new XLogReader(ifs, logFilter, logWriter);
             logReader.processLog();
         }
     }
@@ -260,17 +286,22 @@ public class XLogStreamer {
     private ArrayList<FileInfo> getFileList(File dir, long startTime, long endTime, long logRotationTime,
                                             String logFile) {
         String[] children = dir.list();
+        String fileName;
+        File file;
         ArrayList<FileInfo> fileList = new ArrayList<FileInfo>();
+        
         if (children == null) {
             return fileList;
         }
         else {
-            for (int i = 0; i < children.length; i++) {
-                String filename = children[i];
-                if (!filename.startsWith(logFile) && !filename.equals(logFile)) {
+        	for (int i = 0; i < children.length; i++) {
+        		fileName = children[i];
+        		file = new File(dir.getAbsolutePath(), fileName);
+                	
+                if (!fileName.startsWith(logFile) && !fileName.equals(logFile)) {
                     continue;
                 }
-                File file = new File(dir.getAbsolutePath(), filename);
+                file = new File(dir.getAbsolutePath(), fileName);
                 long modTime = file.lastModified();
                 if (modTime < startTime) {
                     continue;

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,7 @@
 -- Oozie 3.1.0 release
 
+OOZIE-5 Log retrieval for a Coordinator job with large number or actions 
+OOZIE-7 Ability to view the log information corresponding to particular coordinator actions
 OOZIE-124 Update documentation for job-type in WS API
 OOZIE-81 Add an email action to Oozie
 OOZIE-113 merge changes for OOZIE-101 to ActionEndXCommand 


### PR DESCRIPTION
At present the parts of response sent from the server are appended and finally printed. Fix has been made to print the response now and then by getting the commandLine's PrintStream.

Option to pull the log for specific coordinator actions of a coordinator job has been added. This makes it easier to analyze the log when an action re-run is necessary.
