### PR TITLE
CLOSES OOZIE:7 Log retrieval for large number of actions particular coordinator actions

### DIFF
--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -16,8 +16,10 @@ package org.apache.oozie.client;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -125,7 +127,7 @@ public class OozieClient {
     public static enum SYSTEM_MODE {
         NORMAL, NOWEBSERVICE, SAFEMODE
     };
-    
+
     /**
      * debugMode =0 means no debugging. > 0 means debugging on.
      */
@@ -383,7 +385,76 @@ public class OozieClient {
 
         }
 
+        public void call(PrintStream ps) throws OozieClientException {
+            try {
+                URL url = createURL(collection, resource, params);
+                if (validateCommand(url.toString())) {
+                    if (getDebugMode() > 0) {
+                        System.out.println("Connection URL:[" + url + "]");
+                    }
+                    HttpURLConnection conn = createConnection(url, method);
+                    call(conn, ps);
+                }
+                else {
+                    System.out
+                            .println("Option not supported in target server. Supported only on Oozie-2.0 or greater. Use 'oozie help' for details");
+                    throw new OozieClientException(OozieClientException.UNSUPPORTED_VERSION, new Exception());
+                }
+            }
+            catch (IOException ex) {
+                throw new OozieClientException(OozieClientException.IO_ERROR, ex);
+            }
+
+        }
+
         protected abstract T call(HttpURLConnection conn) throws IOException, OozieClientException;
+
+        protected void call(HttpURLConnection conn, PrintStream ps) throws IOException, OozieClientException {
+            if ((conn.getResponseCode() == HttpURLConnection.HTTP_OK)) {
+                InputStream is = conn.getInputStream();
+                InputStreamReader isr = new InputStreamReader(is);
+                try {
+                    sendToOutputStream(isr, -1, ps);
+                }
+                finally {
+                    isr.close();
+                }
+            }
+            else {
+                handleError(conn);
+            }
+        }
+
+        /**
+         * Output the log to command line interface
+         *
+         * @param reader reader to read into a string.
+         * @param maxLen max content length allowed, if -1 there is no limit.
+         * @param ps Printstream of command line interface
+         * @throws IOException
+         */
+        private void sendToOutputStream(Reader reader, int maxLen, PrintStream ps) throws IOException {
+            if (reader == null) {
+                throw new IllegalArgumentException("reader cannot be null");
+            }
+            StringBuilder sb = new StringBuilder();
+            char[] buffer = new char[2048];
+            int read;
+            int count = 0;
+            int noOfCharstoFlush = 1024;
+            while ((read = reader.read(buffer)) > -1) {
+                count += read;
+                if ((maxLen > -1) && (count > maxLen)) {
+                    break;
+                }
+                sb.append(buffer, 0, read);
+                if (sb.length() > noOfCharstoFlush) {
+                    ps.print(sb.toString());
+                    sb = new StringBuilder("");
+                }
+            }
+            ps.print(sb.toString());
+        }
     }
 
     static void handleError(HttpURLConnection conn) throws IOException, OozieClientException {
@@ -687,10 +758,28 @@ public class OozieClient {
         return new JobLog(jobId).call();
     }
 
+    /**
+     * Get the log of a workflow job.
+     *
+     * @param jobId job Id.
+     * @param logRetrievalType Based on which filter criteria the log is retrieved
+     * @param logRetrievalScope Value for the retrieval type
+     * @param ps Printstream of command line interface
+     * @throws OozieClientException thrown if the job info could not be retrieved.
+     */
+    public void getJobLog(String jobId, String logRetrievalType, String logRetrievalScope, PrintStream ps)
+            throws OozieClientException {
+        new JobLog(jobId, logRetrievalType, logRetrievalScope).call(ps);
+    }
+
     private class JobLog extends JobMetadata {
 
         JobLog(String jobId) {
             super(jobId, RestConstants.JOB_SHOW_LOG);
+        }
+
+        JobLog(String jobId, String logRetrievalType, String logRetrievalScope) {
+            super(jobId, logRetrievalType, logRetrievalScope, RestConstants.JOB_SHOW_LOG);
         }
     }
 
@@ -713,10 +802,15 @@ public class OozieClient {
     }
 
     private class JobMetadata extends ClientCallable<String> {
-
         JobMetadata(String jobId, String metaType) {
             super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
                     metaType));
+        }
+
+        JobMetadata(String jobId, String logRetrievalType, String logRetrievalScope, String metaType) {
+            super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
+                    metaType, RestConstants.JOB_LOG_TYPE_PARAM, logRetrievalType, RestConstants.JOB_LOG_SCOPE_PARAM,
+                    logRetrievalScope));
         }
 
         @Override

--- a/client/src/main/java/org/apache/oozie/client/rest/RestConstants.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/RestConstants.java
@@ -59,7 +59,7 @@ public interface RestConstants {
     public static final String JOB_ACTION_RERUN = "rerun";
 
     public static final String JOB_COORD_ACTION_RERUN = "coord-rerun";
-    
+
     public static final String JOB_BUNDLE_ACTION_RERUN = "bundle-rerun";
 
     public static final String JOB_SHOW_PARAM = "show";
@@ -73,9 +73,9 @@ public interface RestConstants {
     public static final String JOB_SHOW_DEFINITION = "definition";
 
     public static final String JOB_BUNDLE_RERUN_COORD_SCOPE_PARAM = "coord-scope";
-    
+
     public static final String JOB_BUNDLE_RERUN_DATE_SCOPE_PARAM = "date-scope";
-    
+
     public static final String JOB_COORD_RERUN_TYPE_PARAM = "type";
 
     public static final String JOB_COORD_RERUN_DATE = "date";
@@ -87,6 +87,12 @@ public interface RestConstants {
     public static final String JOB_COORD_RERUN_REFRESH_PARAM = "refresh";
 
     public static final String JOB_COORD_RERUN_NOCLEANUP_PARAM = "nocleanup";
+
+    public static final String JOB_LOG_ACTION = "action";
+
+    public static final String JOB_LOG_SCOPE_PARAM = "scope";
+
+    public static final String JOB_LOG_TYPE_PARAM = "type";
 
     public static final String JOBS_FILTER_PARAM = "filter";
 

--- a/core/src/main/java/org/apache/oozie/BaseEngine.java
+++ b/core/src/main/java/org/apache/oozie/BaseEngine.java
@@ -51,7 +51,7 @@ import org.apache.oozie.util.XLogStreamer;
 
 public abstract class BaseEngine {
     public static final String USE_XCOMMAND = "oozie.useXCommand";
-    
+
     protected String user;
     protected String authToken;
 
@@ -74,7 +74,9 @@ public abstract class BaseEngine {
     }
 
     /**
-     * Submit a job. <p/> It validates configuration properties.
+     * Submit a job.
+     * <p/>
+     * It validates configuration properties.
      *
      * @param conf job configuration.
      * @param startJob indicates if the job should be started or not.
@@ -133,7 +135,6 @@ public abstract class BaseEngine {
      */
     public abstract void reRun(String jobId, Configuration conf) throws BaseEngineException;
 
-
     /**
      * Return the info about a wf job.
      *
@@ -190,12 +191,14 @@ public abstract class BaseEngine {
      * @param writer writer to stream the log to.
      * @throws IOException thrown if the log cannot be streamed.
      * @throws BaseEngineException thrown if there is error in getting the Workflow/Coordinator Job Information for
-     * jobId.
+     *         jobId.
      */
     public abstract void streamLog(String jobId, Writer writer) throws IOException, BaseEngineException;
 
     /**
-     * Return the workflow Job ID for an external ID. <p/> This is reverse lookup for recovery purposes.
+     * Return the workflow Job ID for an external ID.
+     * <p/>
+     * This is reverse lookup for recovery purposes.
      *
      * @param externalId external ID provided at job submission time.
      * @return the associated workflow job ID if any, <code>null</code> if none.
@@ -203,7 +206,6 @@ public abstract class BaseEngine {
      */
     public abstract String getJobIdForExternalId(String externalId) throws BaseEngineException;
 
-    public abstract String dryrunSubmit(Configuration conf, boolean startJob)
-            throws BaseEngineException;
+    public abstract String dryrunSubmit(Configuration conf, boolean startJob) throws BaseEngineException;
 
 }

--- a/core/src/main/java/org/apache/oozie/CoordinatorEngine.java
+++ b/core/src/main/java/org/apache/oozie/CoordinatorEngine.java
@@ -20,15 +20,16 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.oozie.client.CoordinatorJob;
 import org.apache.oozie.client.OozieClient;
 import org.apache.oozie.client.WorkflowJob;
+import org.apache.oozie.client.rest.RestConstants;
 import org.apache.oozie.command.CommandException;
 import org.apache.oozie.command.coord.CoordActionInfoCommand;
 import org.apache.oozie.command.coord.CoordActionInfoXCommand;
@@ -242,7 +243,7 @@ public class CoordinatorEngine extends BaseEngine {
     public CoordinatorActionInfo reRun(String jobId, String rerunType, String scope, boolean refresh, boolean noCleanup)
             throws BaseEngineException {
         try {
-            if  (useXCommand) {
+            if (useXCommand) {
                 return new CoordRerunXCommand(jobId, rerunType, scope, refresh, noCleanup).call();
             }
             else {
@@ -295,6 +296,88 @@ public class CoordinatorEngine extends BaseEngine {
         Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);
     }
 
+    /**
+     * Add list of actions to the filter based on conditions
+     *
+     * @param jobId Job Id
+     * @param logRetrievalScope Value for the retrieval type
+     * @param logRetrievalType Based on which filter criteria the log is retrieved
+     * @param writer writer to stream the log to
+     * @throws IOException
+     * @throws BaseEngineException
+     * @throws CommandException
+     */
+    public void streamLog(String jobId, String logRetrievalScope, String logRetrievalType, Writer writer)
+            throws IOException, BaseEngineException, CommandException {
+        XLogStreamer.Filter filter = new XLogStreamer.Filter();
+        filter.setParameter(DagXLogInfoService.JOB, jobId);
+
+        if (logRetrievalScope != null && logRetrievalType != null) {
+
+            if (logRetrievalType.equals(RestConstants.JOB_LOG_ACTION)) {
+
+                Set<String> actions = new HashSet<String>();
+                String[] list = logRetrievalScope.split(",");
+                for (String s : list) {
+                    s = s.trim();
+                    if (s.contains("-")) {
+                        String[] range = s.split("-");
+                        if (range.length != 2) {
+                            throw new CommandException(ErrorCode.E0302, "format is wrong for action's range '" + s
+                                    + "'");
+                        }
+                        int start;
+                        int end;
+                        try {
+                            start = Integer.parseInt(range[0].trim());
+                            end = Integer.parseInt(range[1].trim());
+                            if (start > end) {
+                                throw new CommandException(ErrorCode.E0302, "format is wrong for action's range '" + s
+                                        + "'");
+                            }
+                        }
+                        catch (NumberFormatException ne) {
+                            throw new CommandException(ErrorCode.E0302, ne);
+                        }
+                        for (int i = start; i <= end; i++) {
+                            actions.add(jobId + "@" + i);
+                        }
+                    }
+                    else {
+                        try {
+                            Integer.parseInt(s);
+                        }
+                        catch (NumberFormatException ne) {
+                            throw new CommandException(ErrorCode.E0302, "format is wrong for action id'" + s
+                                    + "'. Integer only.");
+                        }
+                        actions.add(jobId + "@" + s);
+                    }
+                }
+
+                Iterator<String> actionsIterator = actions.iterator();
+                StringBuilder commaSeparatedActions = new StringBuilder("");
+                int commaRequired = 0;
+
+                while (actionsIterator.hasNext()) {
+                    if (commaRequired == 1)
+                        commaSeparatedActions.append(",");
+                    commaSeparatedActions.append(actionsIterator.next().toString());
+                    commaRequired = 1;
+                }
+                filter.setParameter(DagXLogInfoService.ACTION, commaSeparatedActions.toString());
+            }
+
+            CoordinatorJobBean job = getCoordJobWithNoActionInfo(jobId);
+            Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);
+        }
+
+        else {
+            CoordinatorJobBean job = getCoordJobWithNoActionInfo(jobId);
+            Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);
+        }
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -338,7 +421,7 @@ public class CoordinatorEngine extends BaseEngine {
             }
             else {
                 CoordSubmitCommand submit = new CoordSubmitCommand(true, conf, getAuthToken());
-                jobId = submit.call();                
+                jobId = submit.call();
             }
             return jobId;
         }
@@ -435,11 +518,11 @@ public class CoordinatorEngine extends BaseEngine {
                     String[] pair = token.split("=");
                     if (pair.length != 2) {
                         throw new CoordinatorEngineException(ErrorCode.E0420, filter,
-                                                             "elements must be name=value pairs");
+                                "elements must be name=value pairs");
                     }
                     if (!FILTER_NAMES.contains(pair[0])) {
                         throw new CoordinatorEngineException(ErrorCode.E0420, filter, XLog.format("invalid name [{0}]",
-                                                                                                  pair[0]));
+                                pair[0]));
                     }
                     if (pair[0].equals("status")) {
                         try {

--- a/core/src/main/java/org/apache/oozie/service/XLogService.java
+++ b/core/src/main/java/org/apache/oozie/service/XLogService.java
@@ -23,7 +23,9 @@ import org.apache.oozie.util.XLog;
 import org.apache.oozie.util.XLogStreamer;
 import org.apache.oozie.util.XConfiguration;
 import org.apache.oozie.BuildInfo;
+import org.apache.oozie.CoordinatorEngine;
 import org.apache.oozie.ErrorCode;
+import org.apache.openjpa.lib.log.Log;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.File;

--- a/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
+++ b/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
@@ -29,6 +29,7 @@ import org.apache.oozie.CoordinatorActionBean;
 import org.apache.oozie.CoordinatorActionInfo;
 import org.apache.oozie.CoordinatorEngine;
 import org.apache.oozie.CoordinatorEngineException;
+import org.apache.oozie.command.CommandException;
 import org.apache.oozie.DagEngine;
 import org.apache.oozie.DagEngineException;
 import org.apache.oozie.ErrorCode;
@@ -47,7 +48,7 @@ import org.json.simple.JSONObject;
 public class V1JobServlet extends BaseJobServlet {
 
     private static final String INSTRUMENTATION_NAME = "v1job";
-
+    
     public V1JobServlet() {
         super(INSTRUMENTATION_NAME);
     }
@@ -886,12 +887,16 @@ public class V1JobServlet extends BaseJobServlet {
                 getUser(request), getAuthToken(request));
 
         String jobId = getResourceName(request);
-
+        String logRetrievalScope = request.getParameter(RestConstants.JOB_LOG_SCOPE_PARAM);
+        String logRetrievalType = request.getParameter(RestConstants.JOB_LOG_TYPE_PARAM);
         try {
-            coordEngine.streamLog(jobId, response.getWriter());
+            coordEngine.streamLog(jobId,logRetrievalScope,logRetrievalType,response.getWriter());
         }
         catch (BaseEngineException ex) {
             throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
+        }
+        catch (CommandException ex) {
+        	throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
         }
     }
 }

--- a/core/src/main/java/org/apache/oozie/util/XLogReader.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogReader.java
@@ -14,6 +14,7 @@
  */
 package org.apache.oozie.util;
 
+import org.apache.oozie.service.XLogService; 
 import org.apache.oozie.util.XLogStreamer;
 
 import java.util.ArrayList;

--- a/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
@@ -20,20 +20,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.*;
+
+import org.apache.oozie.service.XLogService;
+import org.mortbay.log.Log;
 
 /**
  * XLogStreamer streams the given log file to logWriter after applying the given filter.
  */
 public class XLogStreamer {
 
-    /**
+	/**
      * Filter that will construct the regular expression that will be used to filter the log statement. And also checks
      * if the given log message go through the filter. Filters that can be used are logLevel(Multi values separated by
      * "|") jobId appName actionId token
@@ -143,7 +149,7 @@ public class XLogStreamer {
          * Constructs the regular expression according to the filter and assigns it to fileterPattarn. ".*" will be
          * assigned if no filters are set.
          */
-        public void constructPattern() {
+        public void constructPattern() { 
             if (noFilter && logLevels == null) {
                 filterPattern = Pattern.compile(ALLOW_ALL_REGEX);
                 return;
@@ -155,6 +161,22 @@ public class XLogStreamer {
             else {
                 sb.append("(.* - ");
                 for (int i = 0; i < parameters.size(); i++) {
+                    if(parameters.get(i).equals("ACTION"))
+                    {
+                    	String[] actionsList = filterParams.get(parameters.get(i)).split(",");
+                        sb.append("(");
+                    	
+                        for(int counter=0 ; counter<actionsList.length ; counter++)
+                    	{
+                    		if(counter!=0)
+                    			sb.append("|");
+                            sb.append("ACTION" + "\\[");
+                            sb.append(actionsList[counter] + "\\]");
+                    	}
+                    	
+                    	sb.append(") ");
+                    	continue;
+                    }
                     sb.append(parameters.get(i) + "\\[");
                     sb.append(filterParams.get(parameters.get(i)) + "\\] ");
                 }
@@ -162,7 +184,7 @@ public class XLogStreamer {
             }
             filterPattern = Pattern.compile(sb.toString());
         }
-
+        
         public static void reset() {
             parameters.clear();
         }
@@ -196,6 +218,10 @@ public class XLogStreamer {
     public void streamLog(Date startTime, Date endTime) throws IOException {
         long startTimeMillis = 0;
         long endTimeMillis;
+        String fileName;
+        InputStream ifs;
+        XLogReader logReader;
+        
         if (startTime != null) {
             startTimeMillis = startTime.getTime();
         }
@@ -208,9 +234,9 @@ public class XLogStreamer {
         File dir = new File(logPath);
         ArrayList<FileInfo> fileList = getFileList(dir, startTimeMillis, endTimeMillis, logRotation, logFile);
         for (int i = 0; i < fileList.size(); i++) {
-            InputStream ifs;
+        	fileName = fileList.get(i).getFileName();
             ifs = new FileInputStream(fileList.get(i).getFileName());
-            XLogReader logReader = new XLogReader(ifs, logFilter, logWriter);
+            logReader = new XLogReader(ifs, logFilter, logWriter);
             logReader.processLog();
         }
     }
@@ -260,17 +286,22 @@ public class XLogStreamer {
     private ArrayList<FileInfo> getFileList(File dir, long startTime, long endTime, long logRotationTime,
                                             String logFile) {
         String[] children = dir.list();
+        String fileName;
+        File file;
         ArrayList<FileInfo> fileList = new ArrayList<FileInfo>();
+        
         if (children == null) {
             return fileList;
         }
         else {
-            for (int i = 0; i < children.length; i++) {
-                String filename = children[i];
-                if (!filename.startsWith(logFile) && !filename.equals(logFile)) {
+        	for (int i = 0; i < children.length; i++) {
+        		fileName = children[i];
+        		file = new File(dir.getAbsolutePath(), fileName);
+                	
+                if (!fileName.startsWith(logFile) && !fileName.equals(logFile)) {
                     continue;
                 }
-                File file = new File(dir.getAbsolutePath(), filename);
+                file = new File(dir.getAbsolutePath(), fileName);
                 long modTime = file.lastModified();
                 if (modTime < startTime) {
                     continue;

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,7 @@
 -- Oozie 3.1.0 release
 
+OOZIE-5 Log retrieval for a Coordinator job with large number or actions 
+OOZIE-7 Ability to view the log information corresponding to particular coordinator actions
 OOZIE-124 Update documentation for job-type in WS API
 OOZIE-81 Add an email action to Oozie
 OOZIE-113 merge changes for OOZIE-101 to ActionEndXCommand 


### PR DESCRIPTION
At present the parts of response sent from the server are appended and finally printed. Fix has been made to print the response now and then by getting the commandLine's PrintStream.

Option to pull the log for specific coordinator actions of a coordinator job has been added. This makes it easier to analyze the log when an action re-run is necessary.
