### PR TITLE
CLOSES OOZIE:7 Log retrieval for large number of actions particular coorinator actions

### DIFF
--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -139,7 +139,7 @@ public class OozieCLI {
      * Entry point for the Oozie CLI when invoked from the command line.
      * <p/>
      * Upon completion this method exits the JVM with '0' (success) or '-1' (failure).
-     * 
+     *
      * @param args options and arguments for the Oozie CLI.
      */
     public static void main(String[] args) {
@@ -155,7 +155,7 @@ public class OozieCLI {
 
     /**
      * Return Oozie CLI top help lines.
-     * 
+     *
      * @return help lines.
      */
     protected String[] getCLIHelp() {
@@ -307,7 +307,7 @@ public class OozieCLI {
      * It does not exit the JVM.
      * <p/>
      * A CLI instance can be used only once.
-     * 
+     *
      * @param args options and arguments for the Oozie CLI.
      * @return '0' (success), '-1' (failure).
      */
@@ -507,7 +507,7 @@ public class OozieCLI {
      * Create a OozieClient.
      * <p/>
      * It injects any '-Dheader:' as header to the the {@link org.apache.oozie.client.OozieClient}.
-     * 
+     *
      * @param commandLine the parsed command line options.
      * @return a pre configured eXtended workflow client.
      * @throws OozieCLIException thrown if the OozieClient could not be configured.
@@ -523,7 +523,7 @@ public class OozieCLI {
      * Create a XOozieClient.
      * <p/>
      * It injects any '-Dheader:' as header to the the {@link org.apache.oozie.client.OozieClient}.
-     * 
+     *
      * @param commandLine the parsed command line options.
      * @return a pre configured eXtended workflow client.
      * @throws OozieCLIException thrown if the XOozieClient could not be configured.

--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -1217,6 +1217,8 @@ public class OozieCLI {
                         "oozie-workflow-0.1.xsd")));
                 sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
                         "email-action-0.1.xsd")));
+                sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                        "distcp-action-0.1.xsd")));
                 SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
                 Schema schema = factory.newSchema(sources.toArray(new StreamSource[sources.size()]));
                 Validator validator = schema.newValidator();

--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -96,7 +96,6 @@ public class OozieCLI {
     public static final String INFO_OPTION = "info";
     public static final String LOG_OPTION = "log";
     public static final String LOG_ACTION_OPTION = "action";
-    public static final String LOG_DATE_OPTION = "date";
     public static final String DEFINITION_OPTION = "definition";
     public static final String CONFIG_CONTENT_OPTION = "configcontent";
 
@@ -140,7 +139,7 @@ public class OozieCLI {
      * Entry point for the Oozie CLI when invoked from the command line.
      * <p/>
      * Upon completion this method exits the JVM with '0' (success) or '-1' (failure).
-     *
+     * 
      * @param args options and arguments for the Oozie CLI.
      */
     public static void main(String[] args) {
@@ -156,7 +155,7 @@ public class OozieCLI {
 
     /**
      * Return Oozie CLI top help lines.
-     *
+     * 
      * @return help lines.
      */
     protected String[] getCLIHelp() {
@@ -204,7 +203,6 @@ public class OozieCLI {
         Option log = new Option(LOG_OPTION, true, "job log");
         Option log_action = new Option(LOG_ACTION_OPTION, true,
                 "coordinator log retrieval on action ids (requires -log)");
-        Option log_date = new Option(LOG_DATE_OPTION, true, "coordinator log retrieval on action dates (requires -log)");
         Option definition = new Option(DEFINITION_OPTION, true, "job definition");
         Option config_content = new Option(CONFIG_CONTENT_OPTION, true, "job configuration");
         Option verbose = new Option(VERBOSE_OPTION, false, "verbose mode");
@@ -249,7 +247,6 @@ public class OozieCLI {
         jobOptions.addOption(rerun_refresh);
         jobOptions.addOption(rerun_nocleanup);
         jobOptions.addOption(log_action);
-        jobOptions.addOption(log_date);
         jobOptions.addOptionGroup(actions);
         return jobOptions;
     }
@@ -310,7 +307,7 @@ public class OozieCLI {
      * It does not exit the JVM.
      * <p/>
      * A CLI instance can be used only once.
-     *
+     * 
      * @param args options and arguments for the Oozie CLI.
      * @return '0' (success), '-1' (failure).
      */
@@ -510,7 +507,7 @@ public class OozieCLI {
      * Create a OozieClient.
      * <p/>
      * It injects any '-Dheader:' as header to the the {@link org.apache.oozie.client.OozieClient}.
-     *
+     * 
      * @param commandLine the parsed command line options.
      * @return a pre configured eXtended workflow client.
      * @throws OozieCLIException thrown if the OozieClient could not be configured.
@@ -526,7 +523,7 @@ public class OozieCLI {
      * Create a XOozieClient.
      * <p/>
      * It injects any '-Dheader:' as header to the the {@link org.apache.oozie.client.OozieClient}.
-     *
+     * 
      * @param commandLine the parsed command line options.
      * @return a pre configured eXtended workflow client.
      * @throws OozieCLIException thrown if the XOozieClient could not be configured.

--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -366,6 +366,7 @@ public class OozieClient {
         public T call() throws OozieClientException {
             try {
                 URL url = createURL(collection, resource, params);
+                System.out.println(url);
                 if (validateCommand(url.toString())) {
                     if (getDebugMode() > 0) {
                         System.out.println("Connection URL:[" + url + "]");
@@ -748,6 +749,7 @@ public class OozieClient {
 
         @Override
         protected String call(HttpURLConnection conn) throws IOException, OozieClientException {
+            String returnVal = null;
             if ((conn.getResponseCode() == HttpURLConnection.HTTP_OK)) {
                 InputStream is = conn.getInputStream();
                 InputStreamReader isr = new InputStreamReader(is);
@@ -756,7 +758,7 @@ public class OozieClient {
                         sendToOutputStream(isr, -1);
                     }
                     else {
-                        return getReaderAsString(isr, -1);
+                        returnVal = getReaderAsString(isr, -1);
                     }
                 }
                 finally {
@@ -766,7 +768,7 @@ public class OozieClient {
             else {
                 handleError(conn);
             }
-            return null;
+            return returnVal;
         }
 
         /**

--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -366,7 +366,6 @@ public class OozieClient {
         public T call() throws OozieClientException {
             try {
                 URL url = createURL(collection, resource, params);
-                System.out.println(url);
                 if (validateCommand(url.toString())) {
                     if (getDebugMode() > 0) {
                         System.out.println("Connection URL:[" + url + "]");

--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -733,7 +733,6 @@ public class OozieClient {
 
     private class JobMetadata extends ClientCallable<String> {
         PrintStream printStream;
-
         JobMetadata(String jobId, String metaType) {
             super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
                     metaType));
@@ -775,6 +774,9 @@ public class OozieClient {
         private void sendToOutputStream(Reader reader, int maxLen) throws IOException {
             if (reader == null) {
                 throw new IllegalArgumentException("reader cannot be null");
+            }
+            if (printStream == null) {
+                throw new IllegalArgumentException("Output Stream cannot be null");
             }
             StringBuilder sb = new StringBuilder();
             char[] buffer = new char[2048];

--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -374,30 +374,8 @@ public class OozieClient {
                     return call(conn);
                 }
                 else {
-                    System.out
-                            .println("Option not supported in target server. Supported only on Oozie-2.0 or greater. Use 'oozie help' for details");
-                    throw new OozieClientException(OozieClientException.UNSUPPORTED_VERSION, new Exception());
-                }
-            }
-            catch (IOException ex) {
-                throw new OozieClientException(OozieClientException.IO_ERROR, ex);
-            }
-
-        }
-
-        public void call(PrintStream ps) throws OozieClientException {
-            try {
-                URL url = createURL(collection, resource, params);
-                if (validateCommand(url.toString())) {
-                    if (getDebugMode() > 0) {
-                        System.out.println("Connection URL:[" + url + "]");
-                    }
-                    HttpURLConnection conn = createConnection(url, method);
-                    call(conn, ps);
-                }
-                else {
-                    System.out
-                            .println("Option not supported in target server. Supported only on Oozie-2.0 or greater. Use 'oozie help' for details");
+                    System.out.println("Option not supported in target server. Supported only on Oozie-2.0 or greater."
+                            + " Use 'oozie help' for details");
                     throw new OozieClientException(OozieClientException.UNSUPPORTED_VERSION, new Exception());
                 }
             }
@@ -408,53 +386,6 @@ public class OozieClient {
         }
 
         protected abstract T call(HttpURLConnection conn) throws IOException, OozieClientException;
-
-        protected void call(HttpURLConnection conn, PrintStream ps) throws IOException, OozieClientException {
-            if ((conn.getResponseCode() == HttpURLConnection.HTTP_OK)) {
-                InputStream is = conn.getInputStream();
-                InputStreamReader isr = new InputStreamReader(is);
-                try {
-                    sendToOutputStream(isr, -1, ps);
-                }
-                finally {
-                    isr.close();
-                }
-            }
-            else {
-                handleError(conn);
-            }
-        }
-
-        /**
-         * Output the log to command line interface
-         *
-         * @param reader reader to read into a string.
-         * @param maxLen max content length allowed, if -1 there is no limit.
-         * @param ps Printstream of command line interface
-         * @throws IOException
-         */
-        private void sendToOutputStream(Reader reader, int maxLen, PrintStream ps) throws IOException {
-            if (reader == null) {
-                throw new IllegalArgumentException("reader cannot be null");
-            }
-            StringBuilder sb = new StringBuilder();
-            char[] buffer = new char[2048];
-            int read;
-            int count = 0;
-            int noOfCharstoFlush = 1024;
-            while ((read = reader.read(buffer)) > -1) {
-                count += read;
-                if ((maxLen > -1) && (count > maxLen)) {
-                    break;
-                }
-                sb.append(buffer, 0, read);
-                if (sb.length() > noOfCharstoFlush) {
-                    ps.print(sb.toString());
-                    sb = new StringBuilder("");
-                }
-            }
-            ps.print(sb.toString());
-        }
     }
 
     static void handleError(HttpURLConnection conn) throws IOException, OozieClientException {
@@ -759,7 +690,7 @@ public class OozieClient {
     }
 
     /**
-     * Get the log of a workflow job.
+     * Get the log of a job.
      *
      * @param jobId job Id.
      * @param logRetrievalType Based on which filter criteria the log is retrieved
@@ -769,17 +700,16 @@ public class OozieClient {
      */
     public void getJobLog(String jobId, String logRetrievalType, String logRetrievalScope, PrintStream ps)
             throws OozieClientException {
-        new JobLog(jobId, logRetrievalType, logRetrievalScope).call(ps);
+        new JobLog(jobId, logRetrievalType, logRetrievalScope, ps).call();
     }
 
     private class JobLog extends JobMetadata {
-
         JobLog(String jobId) {
             super(jobId, RestConstants.JOB_SHOW_LOG);
         }
 
-        JobLog(String jobId, String logRetrievalType, String logRetrievalScope) {
-            super(jobId, logRetrievalType, logRetrievalScope, RestConstants.JOB_SHOW_LOG);
+        JobLog(String jobId, String logRetrievalType, String logRetrievalScope, PrintStream ps) {
+            super(jobId, logRetrievalType, logRetrievalScope, RestConstants.JOB_SHOW_LOG, ps);
         }
     }
 
@@ -802,28 +732,67 @@ public class OozieClient {
     }
 
     private class JobMetadata extends ClientCallable<String> {
+        PrintStream printStream;
+
         JobMetadata(String jobId, String metaType) {
             super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
                     metaType));
         }
 
-        JobMetadata(String jobId, String logRetrievalType, String logRetrievalScope, String metaType) {
+        JobMetadata(String jobId, String logRetrievalType, String logRetrievalScope, String metaType, PrintStream ps) {
             super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
                     metaType, RestConstants.JOB_LOG_TYPE_PARAM, logRetrievalType, RestConstants.JOB_LOG_SCOPE_PARAM,
                     logRetrievalScope));
+            printStream = ps;
         }
 
         @Override
         protected String call(HttpURLConnection conn) throws IOException, OozieClientException {
             if ((conn.getResponseCode() == HttpURLConnection.HTTP_OK)) {
-
-                String output = getReaderAsString(new InputStreamReader(conn.getInputStream()), -1);
-                return output;
+                InputStream is = conn.getInputStream();
+                InputStreamReader isr = new InputStreamReader(is);
+                try {
+                    sendToOutputStream(isr, -1);
+                }
+                finally {
+                    isr.close();
+                }
             }
             else {
                 handleError(conn);
             }
             return null;
+        }
+
+        /**
+         * Output the log to command line interface
+         *
+         * @param reader reader to read into a string.
+         * @param maxLen max content length allowed, if -1 there is no limit.
+         * @param ps Printstream of command line interface
+         * @throws IOException
+         */
+        private void sendToOutputStream(Reader reader, int maxLen) throws IOException {
+            if (reader == null) {
+                throw new IllegalArgumentException("reader cannot be null");
+            }
+            StringBuilder sb = new StringBuilder();
+            char[] buffer = new char[2048];
+            int read;
+            int count = 0;
+            int noOfCharstoFlush = 1024;
+            while ((read = reader.read(buffer)) > -1) {
+                count += read;
+                if ((maxLen > -1) && (count > maxLen)) {
+                    break;
+                }
+                sb.append(buffer, 0, read);
+                if (sb.length() > noOfCharstoFlush) {
+                    printStream.print(sb.toString());
+                    sb = new StringBuilder("");
+                }
+            }
+            printStream.print(sb.toString());
         }
 
         /**
@@ -839,7 +808,6 @@ public class OozieClient {
             if (reader == null) {
                 throw new IllegalArgumentException("reader cannot be null");
             }
-
             StringBuffer sb = new StringBuffer();
             char[] buffer = new char[2048];
             int read;

--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -733,6 +733,7 @@ public class OozieClient {
 
     private class JobMetadata extends ClientCallable<String> {
         PrintStream printStream;
+
         JobMetadata(String jobId, String metaType) {
             super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
                     metaType));
@@ -751,7 +752,12 @@ public class OozieClient {
                 InputStream is = conn.getInputStream();
                 InputStreamReader isr = new InputStreamReader(is);
                 try {
-                    sendToOutputStream(isr, -1);
+                    if (printStream != null) {
+                        sendToOutputStream(isr, -1);
+                    }
+                    else {
+                        return getReaderAsString(isr, -1);
+                    }
                 }
                 finally {
                     isr.close();
@@ -774,9 +780,6 @@ public class OozieClient {
         private void sendToOutputStream(Reader reader, int maxLen) throws IOException {
             if (reader == null) {
                 throw new IllegalArgumentException("reader cannot be null");
-            }
-            if (printStream == null) {
-                throw new IllegalArgumentException("Output Stream cannot be null");
             }
             StringBuilder sb = new StringBuilder();
             char[] buffer = new char[2048];

--- a/client/src/main/java/org/apache/oozie/client/OozieClient.java
+++ b/client/src/main/java/org/apache/oozie/client/OozieClient.java
@@ -16,8 +16,10 @@ package org.apache.oozie.client;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -125,7 +127,7 @@ public class OozieClient {
     public static enum SYSTEM_MODE {
         NORMAL, NOWEBSERVICE, SAFEMODE
     };
-    
+
     /**
      * debugMode =0 means no debugging. > 0 means debugging on.
      */
@@ -383,7 +385,76 @@ public class OozieClient {
 
         }
 
+        public void call(PrintStream ps) throws OozieClientException {
+            try {
+                URL url = createURL(collection, resource, params);
+                if (validateCommand(url.toString())) {
+                    if (getDebugMode() > 0) {
+                        System.out.println("Connection URL:[" + url + "]");
+                    }
+                    HttpURLConnection conn = createConnection(url, method);
+                    call(conn, ps);
+                }
+                else {
+                    System.out
+                            .println("Option not supported in target server. Supported only on Oozie-2.0 or greater. Use 'oozie help' for details");
+                    throw new OozieClientException(OozieClientException.UNSUPPORTED_VERSION, new Exception());
+                }
+            }
+            catch (IOException ex) {
+                throw new OozieClientException(OozieClientException.IO_ERROR, ex);
+            }
+
+        }
+
         protected abstract T call(HttpURLConnection conn) throws IOException, OozieClientException;
+
+        protected void call(HttpURLConnection conn, PrintStream ps) throws IOException, OozieClientException {
+            if ((conn.getResponseCode() == HttpURLConnection.HTTP_OK)) {
+                InputStream is = conn.getInputStream();
+                InputStreamReader isr = new InputStreamReader(is);
+                try {
+                    sendToOutputStream(isr, -1, ps);
+                }
+                finally {
+                    isr.close();
+                }
+            }
+            else {
+                handleError(conn);
+            }
+        }
+
+        /**
+         * Output the log to command line interface
+         *
+         * @param reader reader to read into a string.
+         * @param maxLen max content length allowed, if -1 there is no limit.
+         * @param ps Printstream of command line interface
+         * @throws IOException
+         */
+        private void sendToOutputStream(Reader reader, int maxLen, PrintStream ps) throws IOException {
+            if (reader == null) {
+                throw new IllegalArgumentException("reader cannot be null");
+            }
+            StringBuilder sb = new StringBuilder();
+            char[] buffer = new char[2048];
+            int read;
+            int count = 0;
+            int noOfCharstoFlush = 1024;
+            while ((read = reader.read(buffer)) > -1) {
+                count += read;
+                if ((maxLen > -1) && (count > maxLen)) {
+                    break;
+                }
+                sb.append(buffer, 0, read);
+                if (sb.length() > noOfCharstoFlush) {
+                    ps.print(sb.toString());
+                    sb = new StringBuilder("");
+                }
+            }
+            ps.print(sb.toString());
+        }
     }
 
     static void handleError(HttpURLConnection conn) throws IOException, OozieClientException {
@@ -687,10 +758,28 @@ public class OozieClient {
         return new JobLog(jobId).call();
     }
 
+    /**
+     * Get the log of a workflow job.
+     *
+     * @param jobId job Id.
+     * @param logRetrievalType Based on which filter criteria the log is retrieved
+     * @param logRetrievalScope Value for the retrieval type
+     * @param ps Printstream of command line interface
+     * @throws OozieClientException thrown if the job info could not be retrieved.
+     */
+    public void getJobLog(String jobId, String logRetrievalType, String logRetrievalScope, PrintStream ps)
+            throws OozieClientException {
+        new JobLog(jobId, logRetrievalType, logRetrievalScope).call(ps);
+    }
+
     private class JobLog extends JobMetadata {
 
         JobLog(String jobId) {
             super(jobId, RestConstants.JOB_SHOW_LOG);
+        }
+
+        JobLog(String jobId, String logRetrievalType, String logRetrievalScope) {
+            super(jobId, logRetrievalType, logRetrievalScope, RestConstants.JOB_SHOW_LOG);
         }
     }
 
@@ -713,10 +802,15 @@ public class OozieClient {
     }
 
     private class JobMetadata extends ClientCallable<String> {
-
         JobMetadata(String jobId, String metaType) {
             super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
                     metaType));
+        }
+
+        JobMetadata(String jobId, String logRetrievalType, String logRetrievalScope, String metaType) {
+            super("GET", RestConstants.JOB, notEmpty(jobId, "jobId"), prepareParams(RestConstants.JOB_SHOW_PARAM,
+                    metaType, RestConstants.JOB_LOG_TYPE_PARAM, logRetrievalType, RestConstants.JOB_LOG_SCOPE_PARAM,
+                    logRetrievalScope));
         }
 
         @Override

--- a/client/src/main/java/org/apache/oozie/client/rest/RestConstants.java
+++ b/client/src/main/java/org/apache/oozie/client/rest/RestConstants.java
@@ -59,7 +59,7 @@ public interface RestConstants {
     public static final String JOB_ACTION_RERUN = "rerun";
 
     public static final String JOB_COORD_ACTION_RERUN = "coord-rerun";
-    
+
     public static final String JOB_BUNDLE_ACTION_RERUN = "bundle-rerun";
 
     public static final String JOB_SHOW_PARAM = "show";
@@ -73,9 +73,9 @@ public interface RestConstants {
     public static final String JOB_SHOW_DEFINITION = "definition";
 
     public static final String JOB_BUNDLE_RERUN_COORD_SCOPE_PARAM = "coord-scope";
-    
+
     public static final String JOB_BUNDLE_RERUN_DATE_SCOPE_PARAM = "date-scope";
-    
+
     public static final String JOB_COORD_RERUN_TYPE_PARAM = "type";
 
     public static final String JOB_COORD_RERUN_DATE = "date";
@@ -87,6 +87,12 @@ public interface RestConstants {
     public static final String JOB_COORD_RERUN_REFRESH_PARAM = "refresh";
 
     public static final String JOB_COORD_RERUN_NOCLEANUP_PARAM = "nocleanup";
+
+    public static final String JOB_LOG_ACTION = "action";
+
+    public static final String JOB_LOG_SCOPE_PARAM = "scope";
+
+    public static final String JOB_LOG_TYPE_PARAM = "type";
 
     public static final String JOBS_FILTER_PARAM = "filter";
 

--- a/client/src/main/resources/distcp-action-0.1.xsd
+++ b/client/src/main/resources/distcp-action-0.1.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:distcp="uri:oozie:distcp-action:0.1" elementFormDefault="qualified"
+           targetNamespace="uri:oozie:distcp-action:0.1">
+
+    <xs:element name="distcp" type="distcp:ACTION"/>
+
+    <xs:complexType name="ACTION">
+        <xs:sequence>
+                <xs:element name="job-tracker" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="name-node" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="prepare" type="distcp:PREPARE" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="configuration" type="distcp:CONFIGURATION" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="java-opts" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="arg" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="CONFIGURATION">
+        <xs:sequence>
+            <xs:element name="property" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" minOccurs="1" maxOccurs="1" type="xs:string"/>
+                        <xs:element name="value" minOccurs="1" maxOccurs="1" type="xs:string"/>
+                        <xs:element name="description" minOccurs="0" maxOccurs="1" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="PREPARE">
+        <xs:sequence>
+            <xs:element name="delete" type="distcp:DELETE" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="mkdir" type="distcp:MKDIR" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DELETE">
+        <xs:attribute name="path" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="MKDIR">
+        <xs:attribute name="path" type="xs:string" use="required"/>
+    </xs:complexType>
+    
+</xs:schema>

--- a/core/src/main/java/org/apache/oozie/BaseEngine.java
+++ b/core/src/main/java/org/apache/oozie/BaseEngine.java
@@ -51,7 +51,7 @@ import org.apache.oozie.util.XLogStreamer;
 
 public abstract class BaseEngine {
     public static final String USE_XCOMMAND = "oozie.useXCommand";
-    
+
     protected String user;
     protected String authToken;
 
@@ -74,7 +74,9 @@ public abstract class BaseEngine {
     }
 
     /**
-     * Submit a job. <p/> It validates configuration properties.
+     * Submit a job.
+     * <p/>
+     * It validates configuration properties.
      *
      * @param conf job configuration.
      * @param startJob indicates if the job should be started or not.
@@ -133,7 +135,6 @@ public abstract class BaseEngine {
      */
     public abstract void reRun(String jobId, Configuration conf) throws BaseEngineException;
 
-
     /**
      * Return the info about a wf job.
      *
@@ -190,12 +191,14 @@ public abstract class BaseEngine {
      * @param writer writer to stream the log to.
      * @throws IOException thrown if the log cannot be streamed.
      * @throws BaseEngineException thrown if there is error in getting the Workflow/Coordinator Job Information for
-     * jobId.
+     *         jobId.
      */
     public abstract void streamLog(String jobId, Writer writer) throws IOException, BaseEngineException;
 
     /**
-     * Return the workflow Job ID for an external ID. <p/> This is reverse lookup for recovery purposes.
+     * Return the workflow Job ID for an external ID.
+     * <p/>
+     * This is reverse lookup for recovery purposes.
      *
      * @param externalId external ID provided at job submission time.
      * @return the associated workflow job ID if any, <code>null</code> if none.
@@ -203,7 +206,6 @@ public abstract class BaseEngine {
      */
     public abstract String getJobIdForExternalId(String externalId) throws BaseEngineException;
 
-    public abstract String dryrunSubmit(Configuration conf, boolean startJob)
-            throws BaseEngineException;
+    public abstract String dryrunSubmit(Configuration conf, boolean startJob) throws BaseEngineException;
 
 }

--- a/core/src/main/java/org/apache/oozie/CoordinatorEngine.java
+++ b/core/src/main/java/org/apache/oozie/CoordinatorEngine.java
@@ -20,15 +20,16 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.oozie.client.CoordinatorJob;
 import org.apache.oozie.client.OozieClient;
 import org.apache.oozie.client.WorkflowJob;
+import org.apache.oozie.client.rest.RestConstants;
 import org.apache.oozie.command.CommandException;
 import org.apache.oozie.command.coord.CoordActionInfoCommand;
 import org.apache.oozie.command.coord.CoordActionInfoXCommand;
@@ -242,7 +243,7 @@ public class CoordinatorEngine extends BaseEngine {
     public CoordinatorActionInfo reRun(String jobId, String rerunType, String scope, boolean refresh, boolean noCleanup)
             throws BaseEngineException {
         try {
-            if  (useXCommand) {
+            if (useXCommand) {
                 return new CoordRerunXCommand(jobId, rerunType, scope, refresh, noCleanup).call();
             }
             else {
@@ -295,6 +296,88 @@ public class CoordinatorEngine extends BaseEngine {
         Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);
     }
 
+    /**
+     * Add list of actions to the filter based on conditions
+     *
+     * @param jobId Job Id
+     * @param logRetrievalScope Value for the retrieval type
+     * @param logRetrievalType Based on which filter criteria the log is retrieved
+     * @param writer writer to stream the log to
+     * @throws IOException
+     * @throws BaseEngineException
+     * @throws CommandException
+     */
+    public void streamLog(String jobId, String logRetrievalScope, String logRetrievalType, Writer writer)
+            throws IOException, BaseEngineException, CommandException {
+        XLogStreamer.Filter filter = new XLogStreamer.Filter();
+        filter.setParameter(DagXLogInfoService.JOB, jobId);
+
+        if (logRetrievalScope != null && logRetrievalType != null) {
+
+            if (logRetrievalType.equals(RestConstants.JOB_LOG_ACTION)) {
+
+                Set<String> actions = new HashSet<String>();
+                String[] list = logRetrievalScope.split(",");
+                for (String s : list) {
+                    s = s.trim();
+                    if (s.contains("-")) {
+                        String[] range = s.split("-");
+                        if (range.length != 2) {
+                            throw new CommandException(ErrorCode.E0302, "format is wrong for action's range '" + s
+                                    + "'");
+                        }
+                        int start;
+                        int end;
+                        try {
+                            start = Integer.parseInt(range[0].trim());
+                            end = Integer.parseInt(range[1].trim());
+                            if (start > end) {
+                                throw new CommandException(ErrorCode.E0302, "format is wrong for action's range '" + s
+                                        + "'");
+                            }
+                        }
+                        catch (NumberFormatException ne) {
+                            throw new CommandException(ErrorCode.E0302, ne);
+                        }
+                        for (int i = start; i <= end; i++) {
+                            actions.add(jobId + "@" + i);
+                        }
+                    }
+                    else {
+                        try {
+                            Integer.parseInt(s);
+                        }
+                        catch (NumberFormatException ne) {
+                            throw new CommandException(ErrorCode.E0302, "format is wrong for action id'" + s
+                                    + "'. Integer only.");
+                        }
+                        actions.add(jobId + "@" + s);
+                    }
+                }
+
+                Iterator<String> actionsIterator = actions.iterator();
+                StringBuilder commaSeparatedActions = new StringBuilder("");
+                int commaRequired = 0;
+
+                while (actionsIterator.hasNext()) {
+                    if (commaRequired == 1)
+                        commaSeparatedActions.append(",");
+                    commaSeparatedActions.append(actionsIterator.next().toString());
+                    commaRequired = 1;
+                }
+                filter.setParameter(DagXLogInfoService.ACTION, commaSeparatedActions.toString());
+            }
+
+            CoordinatorJobBean job = getCoordJobWithNoActionInfo(jobId);
+            Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);
+        }
+
+        else {
+            CoordinatorJobBean job = getCoordJobWithNoActionInfo(jobId);
+            Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);
+        }
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -338,7 +421,7 @@ public class CoordinatorEngine extends BaseEngine {
             }
             else {
                 CoordSubmitCommand submit = new CoordSubmitCommand(true, conf, getAuthToken());
-                jobId = submit.call();                
+                jobId = submit.call();
             }
             return jobId;
         }
@@ -435,11 +518,11 @@ public class CoordinatorEngine extends BaseEngine {
                     String[] pair = token.split("=");
                     if (pair.length != 2) {
                         throw new CoordinatorEngineException(ErrorCode.E0420, filter,
-                                                             "elements must be name=value pairs");
+                                "elements must be name=value pairs");
                     }
                     if (!FILTER_NAMES.contains(pair[0])) {
                         throw new CoordinatorEngineException(ErrorCode.E0420, filter, XLog.format("invalid name [{0}]",
-                                                                                                  pair[0]));
+                                pair[0]));
                     }
                     if (pair[0].equals("status")) {
                         try {

--- a/core/src/main/java/org/apache/oozie/CoordinatorEngine.java
+++ b/core/src/main/java/org/apache/oozie/CoordinatorEngine.java
@@ -311,11 +311,8 @@ public class CoordinatorEngine extends BaseEngine {
             throws IOException, BaseEngineException, CommandException {
         XLogStreamer.Filter filter = new XLogStreamer.Filter();
         filter.setParameter(DagXLogInfoService.JOB, jobId);
-
         if (logRetrievalScope != null && logRetrievalType != null) {
-
             if (logRetrievalType.equals(RestConstants.JOB_LOG_ACTION)) {
-
                 Set<String> actions = new HashSet<String>();
                 String[] list = logRetrievalScope.split(",");
                 for (String s : list) {
@@ -360,18 +357,17 @@ public class CoordinatorEngine extends BaseEngine {
                 int commaRequired = 0;
 
                 while (actionsIterator.hasNext()) {
-                    if (commaRequired == 1)
+                    if (commaRequired == 1) {
                         commaSeparatedActions.append(",");
+                    }
                     commaSeparatedActions.append(actionsIterator.next().toString());
                     commaRequired = 1;
                 }
                 filter.setParameter(DagXLogInfoService.ACTION, commaSeparatedActions.toString());
             }
-
             CoordinatorJobBean job = getCoordJobWithNoActionInfo(jobId);
             Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);
         }
-
         else {
             CoordinatorJobBean job = getCoordJobWithNoActionInfo(jobId);
             Services.get().get(XLogService.class).streamLog(filter, job.getCreatedTime(), new Date(), writer);

--- a/core/src/main/java/org/apache/oozie/action/hadoop/DistcpActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/DistcpActionExecutor.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. See accompanying LICENSE file.
+ */
+
+package org.apache.oozie.action.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.util.XLog;
+import org.jdom.Element;
+
+
+public class DistcpActionExecutor extends JavaActionExecutor{
+    public static final String CONF_OOZIE_DISTCP_ACTION_MAIN_CLASS = "org.apache.hadoop.tools.DistCp";
+    public static final String CLASS_NAMES = "oozie.actions.main.classnames";
+    private static final XLog LOG = XLog.getLog(DistcpActionExecutor.class);
+    public static final String DISTCP_TYPE = "distcp";
+
+    public DistcpActionExecutor() {
+        super("distcp");
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.oozie.action.hadoop.JavaActionExecutor#getLauncherMain(org.apache.hadoop.conf.Configuration, org.jdom.Element)
+     */
+    @Override
+    protected String getLauncherMain(Configuration launcherConf, Element actionXml) {
+        String classNameDistcp = CONF_OOZIE_DISTCP_ACTION_MAIN_CLASS;
+        String name = getClassNamebyType(DISTCP_TYPE);
+        if(name != null){
+            classNameDistcp = name;
+        }
+        return launcherConf.get(LauncherMapper.CONF_OOZIE_ACTION_MAIN_CLASS, classNameDistcp);
+    }
+
+    /**
+     * This function returns the Action classes names from the configuration
+     *
+     * @param type This is type of the action classes
+     * @return Name of the class from the configuration
+     */
+    public static String getClassNamebyType(String type){
+        Configuration conf = Services.get().getConf();
+        String classname = null;
+        if (conf.get(CLASS_NAMES, "").trim().length() > 0) {
+            for (String function : conf.getStrings(CLASS_NAMES)) {
+                function = DistcpActionExecutor.Trim(function);
+                LOG.debug("class for Distcp Action: " + function);
+                String[] str = function.split("=");
+                if (str.length > 0) {
+                    if(type.equalsIgnoreCase(str[0])){
+                        classname = new String(str[1]);
+                    }
+                }
+            }
+        }
+        return classname;
+    }
+
+    /**
+     * To trim string
+     *
+     * @param str
+     * @return trim string
+     */
+    public static String Trim(String str) {
+        if (str != null) {
+            str = str.replaceAll("\\n", "");
+            str = str.replaceAll("\\t", "");
+            str = str.trim();
+        }
+        return str;
+    }
+}

--- a/core/src/main/java/org/apache/oozie/service/XLogService.java
+++ b/core/src/main/java/org/apache/oozie/service/XLogService.java
@@ -23,7 +23,9 @@ import org.apache.oozie.util.XLog;
 import org.apache.oozie.util.XLogStreamer;
 import org.apache.oozie.util.XConfiguration;
 import org.apache.oozie.BuildInfo;
+import org.apache.oozie.CoordinatorEngine;
 import org.apache.oozie.ErrorCode;
+import org.apache.openjpa.lib.log.Log;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.File;

--- a/core/src/main/java/org/apache/oozie/service/XLogService.java
+++ b/core/src/main/java/org/apache/oozie/service/XLogService.java
@@ -185,8 +185,8 @@ public class XLogService implements Service, Instrumentable {
         }
         String logFile = conf.get("log4j.appender.oozie.File");
         if (logFile == null) {
-            log
-                    .warn("Oozie WS log will be disabled, missing property 'log4j.appender.oozie.File' for 'oozie' appender");
+            log.warn("Oozie WS log will be disabled, missing property 'log4j.appender.oozie.File' for 'oozie' "
+                    + "appender");
         }
         else {
             logFile = logFile.trim();

--- a/core/src/main/java/org/apache/oozie/service/XLogService.java
+++ b/core/src/main/java/org/apache/oozie/service/XLogService.java
@@ -23,9 +23,7 @@ import org.apache.oozie.util.XLog;
 import org.apache.oozie.util.XLogStreamer;
 import org.apache.oozie.util.XConfiguration;
 import org.apache.oozie.BuildInfo;
-import org.apache.oozie.CoordinatorEngine;
 import org.apache.oozie.ErrorCode;
-import org.apache.openjpa.lib.log.Log;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.File;
@@ -39,7 +37,7 @@ import java.util.Map;
 import java.util.Date;
 
 /**
- * Built-in service that initializes and manages Logging via  Log4j.
+ * Built-in service that initializes and manages Logging via Log4j.
  * <p/>
  * Oozie Lo4gj default configuration file is <code>oozie-log4j.properties</code>.
  * <p/>
@@ -54,8 +52,8 @@ import java.util.Date;
  * <p/>
  * If the Log4j configuration file is loaded from the classpath, automatic reloading is disabled.
  * <p/>
- * the automatic reloading interval is defined by the Java System property <code>oozie.log4j.reload</code>.
- * The default value is 10 seconds.
+ * the automatic reloading interval is defined by the Java System property <code>oozie.log4j.reload</code>. The default
+ * value is 10 seconds.
  */
 public class XLogService implements Service, Instrumentable {
     private static final String INSTRUMENTATION_GROUP = "logging";
@@ -150,10 +148,9 @@ public class XLogService implements Service, Instrumentable {
             log = new XLog(LogFactory.getLog(getClass()));
 
             log.info(XLog.OPS, STARTUP_MESSAGE, BuildInfo.getBuildInfo().getProperty(BuildInfo.BUILD_VERSION),
-                     BuildInfo.getBuildInfo().getProperty(BuildInfo.BUILD_USER_NAME), BuildInfo.getBuildInfo()
-                    .getProperty(BuildInfo.BUILD_TIME), BuildInfo.getBuildInfo().getProperty(
-                    BuildInfo.BUILD_VC_REVISION), BuildInfo.getBuildInfo()
-                    .getProperty(BuildInfo.BUILD_VC_URL));
+                    BuildInfo.getBuildInfo().getProperty(BuildInfo.BUILD_USER_NAME), BuildInfo.getBuildInfo()
+                            .getProperty(BuildInfo.BUILD_TIME), BuildInfo.getBuildInfo().getProperty(
+                            BuildInfo.BUILD_VC_REVISION), BuildInfo.getBuildInfo().getProperty(BuildInfo.BUILD_VC_URL));
 
             String from = (fromClasspath) ? "CLASSPATH" : configPath;
             String reload = (fromClasspath) ? "disabled" : Long.toString(interval) + " sec";
@@ -188,14 +185,15 @@ public class XLogService implements Service, Instrumentable {
         }
         String logFile = conf.get("log4j.appender.oozie.File");
         if (logFile == null) {
-            log.warn("Oozie WS log will be disabled, missing property 'log4j.appender.oozie.File' for 'oozie' appender");
+            log
+                    .warn("Oozie WS log will be disabled, missing property 'log4j.appender.oozie.File' for 'oozie' appender");
         }
         else {
             logFile = logFile.trim();
             int i = logFile.lastIndexOf("/");
             if (i == -1) {
                 log.warn("Oozie WS log will be disabled, log file is not an absolute path [{0}] for 'oozie' appender",
-                         logFile);
+                        logFile);
                 logOverWS = false;
             }
             else {
@@ -215,7 +213,7 @@ public class XLogService implements Service, Instrumentable {
                         }
                         else {
                             log.warn("Oozie WS log will be disabled, DatePattern [{0}] should end with 'HH' or 'dd'",
-                                     pattern);
+                                    pattern);
                             logOverWS = false;
                         }
                     }
@@ -260,8 +258,9 @@ public class XLogService implements Service, Instrumentable {
     }
 
     /**
-     * Instruments the log service. <p/> It sets instrumentation variables indicating the config file, reload interval
-     * and if loaded from the classpath.
+     * Instruments the log service.
+     * <p/>
+     * It sets instrumentation variables indicating the config file, reload interval and if loaded from the classpath.
      *
      * @param instr instrumentation to use.
      */

--- a/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
+++ b/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
@@ -48,7 +48,7 @@ import org.json.simple.JSONObject;
 public class V1JobServlet extends BaseJobServlet {
 
     private static final String INSTRUMENTATION_NAME = "v1job";
-    
+
     public V1JobServlet() {
         super(INSTRUMENTATION_NAME);
     }
@@ -161,6 +161,7 @@ public class V1JobServlet extends BaseJobServlet {
      * @throws XServletException
      * @throws IOException
      */
+    @Override
     protected void changeJob(HttpServletRequest request, HttpServletResponse response) throws XServletException,
             IOException {
         String jobId = getResourceName(request);
@@ -275,9 +276,9 @@ public class V1JobServlet extends BaseJobServlet {
 
     /**
      * Start wf job
-     * 
+     *
      * @param request servlet request
-     * @param response servlet response 
+     * @param response servlet response
      * @throws XServletException
      */
     private void startWorkflowJob(HttpServletRequest request, HttpServletResponse response) throws XServletException {
@@ -374,7 +375,7 @@ public class V1JobServlet extends BaseJobServlet {
 
     /**
      * Suspend a wf job
-     * 
+     *
      * @param request servlet request
      * @param response servlet response
      * @throws XServletException
@@ -507,7 +508,7 @@ public class V1JobServlet extends BaseJobServlet {
             throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
         }
     }
-    
+
     /**
      * Change a bundle job
      *
@@ -531,7 +532,7 @@ public class V1JobServlet extends BaseJobServlet {
 
     /**
      * Rerun a wf job
-     * 
+     *
      * @param request servlet request
      * @param response servlet response
      * @param conf configuration object
@@ -653,8 +654,8 @@ public class V1JobServlet extends BaseJobServlet {
 
     /**
      * Get wf action info
-     * 
-     * @param request servlet request 
+     *
+     * @param request servlet request
      * @param response servlet response
      * @return JsonBean WorkflowActionBean
      * @throws XServletException
@@ -678,7 +679,7 @@ public class V1JobServlet extends BaseJobServlet {
 
     /**
      * Get coord job info
-     * 
+     *
      * @param request servlet request
      * @param response servlet response
      * @return JsonBean CoordinatorJobBean
@@ -761,7 +762,7 @@ public class V1JobServlet extends BaseJobServlet {
 
     /**
      * Get wf job definition
-     * 
+     *
      * @param request servlet request
      * @param response servlet response
      * @return String wf definition
@@ -833,7 +834,7 @@ public class V1JobServlet extends BaseJobServlet {
 
     /**
      * Stream wf job log
-     * 
+     *
      * @param request servlet request
      * @param response servlet response
      * @throws XServletException
@@ -875,7 +876,7 @@ public class V1JobServlet extends BaseJobServlet {
     /**
      * Stream coordinator job log
      *
-     * @param request servlet request 
+     * @param request servlet request
      * @param response servlet response
      * @throws XServletException
      * @throws IOException
@@ -885,18 +886,17 @@ public class V1JobServlet extends BaseJobServlet {
 
         CoordinatorEngine coordEngine = Services.get().get(CoordinatorEngineService.class).getCoordinatorEngine(
                 getUser(request), getAuthToken(request));
-
         String jobId = getResourceName(request);
         String logRetrievalScope = request.getParameter(RestConstants.JOB_LOG_SCOPE_PARAM);
         String logRetrievalType = request.getParameter(RestConstants.JOB_LOG_TYPE_PARAM);
         try {
-            coordEngine.streamLog(jobId,logRetrievalScope,logRetrievalType,response.getWriter());
+            coordEngine.streamLog(jobId, logRetrievalScope, logRetrievalType, response.getWriter());
         }
         catch (BaseEngineException ex) {
             throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
         }
         catch (CommandException ex) {
-        	throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
+            throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
         }
     }
 }

--- a/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
+++ b/core/src/main/java/org/apache/oozie/servlet/V1JobServlet.java
@@ -29,6 +29,7 @@ import org.apache.oozie.CoordinatorActionBean;
 import org.apache.oozie.CoordinatorActionInfo;
 import org.apache.oozie.CoordinatorEngine;
 import org.apache.oozie.CoordinatorEngineException;
+import org.apache.oozie.command.CommandException;
 import org.apache.oozie.DagEngine;
 import org.apache.oozie.DagEngineException;
 import org.apache.oozie.ErrorCode;
@@ -47,7 +48,7 @@ import org.json.simple.JSONObject;
 public class V1JobServlet extends BaseJobServlet {
 
     private static final String INSTRUMENTATION_NAME = "v1job";
-
+    
     public V1JobServlet() {
         super(INSTRUMENTATION_NAME);
     }
@@ -886,12 +887,16 @@ public class V1JobServlet extends BaseJobServlet {
                 getUser(request), getAuthToken(request));
 
         String jobId = getResourceName(request);
-
+        String logRetrievalScope = request.getParameter(RestConstants.JOB_LOG_SCOPE_PARAM);
+        String logRetrievalType = request.getParameter(RestConstants.JOB_LOG_TYPE_PARAM);
         try {
-            coordEngine.streamLog(jobId, response.getWriter());
+            coordEngine.streamLog(jobId,logRetrievalScope,logRetrievalType,response.getWriter());
         }
         catch (BaseEngineException ex) {
             throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
+        }
+        catch (CommandException ex) {
+        	throw new XServletException(HttpServletResponse.SC_BAD_REQUEST, ex);
         }
     }
 }

--- a/core/src/main/java/org/apache/oozie/util/XLogReader.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogReader.java
@@ -14,7 +14,6 @@
  */
 package org.apache.oozie.util;
 
-import org.apache.oozie.service.XLogService; 
 import org.apache.oozie.util.XLogStreamer;
 
 import java.util.ArrayList;

--- a/core/src/main/java/org/apache/oozie/util/XLogReader.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogReader.java
@@ -14,6 +14,7 @@
  */
 package org.apache.oozie.util;
 
+import org.apache.oozie.service.XLogService; 
 import org.apache.oozie.util.XLogStreamer;
 
 import java.util.ArrayList;

--- a/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
@@ -20,20 +20,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.*;
+
+import org.apache.oozie.service.XLogService;
+import org.mortbay.log.Log;
 
 /**
  * XLogStreamer streams the given log file to logWriter after applying the given filter.
  */
 public class XLogStreamer {
 
-    /**
+	/**
      * Filter that will construct the regular expression that will be used to filter the log statement. And also checks
      * if the given log message go through the filter. Filters that can be used are logLevel(Multi values separated by
      * "|") jobId appName actionId token
@@ -143,7 +149,7 @@ public class XLogStreamer {
          * Constructs the regular expression according to the filter and assigns it to fileterPattarn. ".*" will be
          * assigned if no filters are set.
          */
-        public void constructPattern() {
+        public void constructPattern() { 
             if (noFilter && logLevels == null) {
                 filterPattern = Pattern.compile(ALLOW_ALL_REGEX);
                 return;
@@ -155,6 +161,22 @@ public class XLogStreamer {
             else {
                 sb.append("(.* - ");
                 for (int i = 0; i < parameters.size(); i++) {
+                    if(parameters.get(i).equals("ACTION"))
+                    {
+                    	String[] actionsList = filterParams.get(parameters.get(i)).split(",");
+                        sb.append("(");
+                    	
+                        for(int counter=0 ; counter<actionsList.length ; counter++)
+                    	{
+                    		if(counter!=0)
+                    			sb.append("|");
+                            sb.append("ACTION" + "\\[");
+                            sb.append(actionsList[counter] + "\\]");
+                    	}
+                    	
+                    	sb.append(") ");
+                    	continue;
+                    }
                     sb.append(parameters.get(i) + "\\[");
                     sb.append(filterParams.get(parameters.get(i)) + "\\] ");
                 }
@@ -162,7 +184,7 @@ public class XLogStreamer {
             }
             filterPattern = Pattern.compile(sb.toString());
         }
-
+        
         public static void reset() {
             parameters.clear();
         }
@@ -196,6 +218,10 @@ public class XLogStreamer {
     public void streamLog(Date startTime, Date endTime) throws IOException {
         long startTimeMillis = 0;
         long endTimeMillis;
+        String fileName;
+        InputStream ifs;
+        XLogReader logReader;
+        
         if (startTime != null) {
             startTimeMillis = startTime.getTime();
         }
@@ -208,9 +234,9 @@ public class XLogStreamer {
         File dir = new File(logPath);
         ArrayList<FileInfo> fileList = getFileList(dir, startTimeMillis, endTimeMillis, logRotation, logFile);
         for (int i = 0; i < fileList.size(); i++) {
-            InputStream ifs;
+        	fileName = fileList.get(i).getFileName();
             ifs = new FileInputStream(fileList.get(i).getFileName());
-            XLogReader logReader = new XLogReader(ifs, logFilter, logWriter);
+            logReader = new XLogReader(ifs, logFilter, logWriter);
             logReader.processLog();
         }
     }
@@ -260,17 +286,22 @@ public class XLogStreamer {
     private ArrayList<FileInfo> getFileList(File dir, long startTime, long endTime, long logRotationTime,
                                             String logFile) {
         String[] children = dir.list();
+        String fileName;
+        File file;
         ArrayList<FileInfo> fileList = new ArrayList<FileInfo>();
+        
         if (children == null) {
             return fileList;
         }
         else {
-            for (int i = 0; i < children.length; i++) {
-                String filename = children[i];
-                if (!filename.startsWith(logFile) && !filename.equals(logFile)) {
+        	for (int i = 0; i < children.length; i++) {
+        		fileName = children[i];
+        		file = new File(dir.getAbsolutePath(), fileName);
+                	
+                if (!fileName.startsWith(logFile) && !fileName.equals(logFile)) {
                     continue;
                 }
-                File file = new File(dir.getAbsolutePath(), filename);
+                file = new File(dir.getAbsolutePath(), fileName);
                 long modTime = file.lastModified();
                 if (modTime < startTime) {
                     continue;

--- a/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
+++ b/core/src/main/java/org/apache/oozie/util/XLogStreamer.java
@@ -20,26 +20,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.zip.*;
-
-import org.apache.oozie.service.XLogService;
-import org.mortbay.log.Log;
 
 /**
  * XLogStreamer streams the given log file to logWriter after applying the given filter.
  */
 public class XLogStreamer {
 
-	/**
+    /**
      * Filter that will construct the regular expression that will be used to filter the log statement. And also checks
      * if the given log message go through the filter. Filters that can be used are logLevel(Multi values separated by
      * "|") jobId appName actionId token
@@ -51,7 +45,7 @@ public class XLogStreamer {
         private boolean noFilter;
         private Pattern filterPattern;
 
-        //TODO Patterns to be read from config file
+        // TODO Patterns to be read from config file
         private static final String DEFAULT_REGEX = "[^\\]]*";
 
         public static final String ALLOW_ALL_REGEX = "(.*)";
@@ -149,7 +143,7 @@ public class XLogStreamer {
          * Constructs the regular expression according to the filter and assigns it to fileterPattarn. ".*" will be
          * assigned if no filters are set.
          */
-        public void constructPattern() { 
+        public void constructPattern() {
             if (noFilter && logLevels == null) {
                 filterPattern = Pattern.compile(ALLOW_ALL_REGEX);
                 return;
@@ -161,21 +155,20 @@ public class XLogStreamer {
             else {
                 sb.append("(.* - ");
                 for (int i = 0; i < parameters.size(); i++) {
-                    if(parameters.get(i).equals("ACTION"))
-                    {
-                    	String[] actionsList = filterParams.get(parameters.get(i)).split(",");
+                    if (parameters.get(i).equals("ACTION")) {
+                        String[] actionsList = filterParams.get(parameters.get(i)).split(",");
                         sb.append("(");
-                    	
-                        for(int counter=0 ; counter<actionsList.length ; counter++)
-                    	{
-                    		if(counter!=0)
-                    			sb.append("|");
+
+                        for (int counter = 0; counter < actionsList.length; counter++) {
+                            if (counter != 0) {
+                                sb.append("|");
+                            }
                             sb.append("ACTION" + "\\[");
                             sb.append(actionsList[counter] + "\\]");
-                    	}
-                    	
-                    	sb.append(") ");
-                    	continue;
+                        }
+
+                        sb.append(") ");
+                        continue;
                     }
                     sb.append(parameters.get(i) + "\\[");
                     sb.append(filterParams.get(parameters.get(i)) + "\\] ");
@@ -184,7 +177,7 @@ public class XLogStreamer {
             }
             filterPattern = Pattern.compile(sb.toString());
         }
-        
+
         public static void reset() {
             parameters.clear();
         }
@@ -221,7 +214,7 @@ public class XLogStreamer {
         String fileName;
         InputStream ifs;
         XLogReader logReader;
-        
+
         if (startTime != null) {
             startTimeMillis = startTime.getTime();
         }
@@ -234,7 +227,7 @@ public class XLogStreamer {
         File dir = new File(logPath);
         ArrayList<FileInfo> fileList = getFileList(dir, startTimeMillis, endTimeMillis, logRotation, logFile);
         for (int i = 0; i < fileList.size(); i++) {
-        	fileName = fileList.get(i).getFileName();
+            fileName = fileList.get(i).getFileName();
             ifs = new FileInputStream(fileList.get(i).getFileName());
             logReader = new XLogReader(ifs, logFilter, logWriter);
             logReader.processLog();
@@ -263,11 +256,13 @@ public class XLogStreamer {
 
         public int compareTo(FileInfo fileInfo) {
             long diff = this.modTime - fileInfo.modTime;
-            if(diff > 0) {
+            if (diff > 0) {
                 return 1;
-            } else if(diff < 0) {
+            }
+            else if (diff < 0) {
                 return -1;
-            } else {
+            }
+            else {
                 return 0;
             }
         }
@@ -283,21 +278,19 @@ public class XLogStreamer {
      * @param logFile
      * @return List of files to be streamed
      */
-    private ArrayList<FileInfo> getFileList(File dir, long startTime, long endTime, long logRotationTime,
-                                            String logFile) {
+    private ArrayList<FileInfo> getFileList(File dir, long startTime, long endTime, long logRotationTime, String logFile) {
         String[] children = dir.list();
         String fileName;
         File file;
         ArrayList<FileInfo> fileList = new ArrayList<FileInfo>();
-        
+
         if (children == null) {
             return fileList;
         }
         else {
-        	for (int i = 0; i < children.length; i++) {
-        		fileName = children[i];
-        		file = new File(dir.getAbsolutePath(), fileName);
-                	
+            for (int i = 0; i < children.length; i++) {
+                fileName = children[i];
+                file = new File(dir.getAbsolutePath(), fileName);
                 if (!fileName.startsWith(logFile) && !fileName.equals(logFile)) {
                     continue;
                 }

--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -1294,6 +1294,15 @@
         </description>
     </property>
 
+	<property>
+        <name>oozie.actions.main.classnames</name>
+        <value>distcp=org.apache.hadoop.tools.DistCp</value>
+        <description>
+            A list of class name mapping for Action classes
+        </description>
+    </property>
+	
+	
     <property>
         <name>oozie.service.WorkflowAppService.system.libpath</name>
         <value>/user/${user.name}/share/lib</value>

--- a/core/src/test/java/org/apache/oozie/action/hadoop/TestDistCpActionExecutor.java
+++ b/core/src/test/java/org/apache/oozie/action/hadoop/TestDistCpActionExecutor.java
@@ -1,0 +1,99 @@
+package org.apache.oozie.action.hadoop;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobClient;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobID;
+import org.apache.hadoop.mapred.RunningJob;
+import org.apache.oozie.WorkflowActionBean;
+import org.apache.oozie.WorkflowJobBean;
+import org.apache.oozie.client.OozieClient;
+import org.apache.oozie.client.WorkflowAction;
+import org.apache.oozie.service.WorkflowAppService;
+import org.apache.oozie.util.IOUtils;
+import org.apache.oozie.util.XConfiguration;
+
+public class TestDistCpActionExecutor extends ActionExecutorTestCase{
+
+    @Override
+    protected void setSystemProps() {
+        super.setSystemProps();
+        setSystemProperty("oozie.service.ActionService.executor.classes", DistcpActionExecutor.class.getName());
+    }
+
+    public void testSimpestdistCpSubmitOK() throws Exception {
+        String actionXml = "<distcp>" +
+                "<job-tracker>" + getJobTrackerUri() + "</job-tracker>" +
+                "<name-node>" + getNameNodeUri() + "</name-node>" +
+                "<arg>-Dmyqueue</arg>" +
+                "<arg>input</arg>"+
+                "<arg>output</arg>" +
+                "</distcp>";
+        Context context = createContext(actionXml);
+        final RunningJob runningJob = submitAction(context);
+        waitFor(60 * 1000, new Predicate() {
+            public boolean evaluate() throws Exception {
+                return runningJob.isComplete();
+            }
+        });
+        assertTrue(runningJob.isSuccessful());
+    }
+
+
+    protected Context createContext(String actionXml) throws Exception {
+        DistcpActionExecutor ae = new DistcpActionExecutor();
+
+        Path appJarPath = new Path("lib/test.jar");
+        File jarFile = IOUtils.createJar(new File(getTestCaseDir()), "test.jar", LauncherMainTester.class);
+        InputStream is = new FileInputStream(jarFile);
+        OutputStream os = getFileSystem().create(new Path(getAppPath(), "lib/test.jar"));
+        IOUtils.copyStream(is, os);
+
+        Path appSoPath = new Path("lib/test.so");
+        getFileSystem().create(new Path(getAppPath(), appSoPath)).close();
+
+        XConfiguration protoConf = new XConfiguration();
+        protoConf.set(WorkflowAppService.HADOOP_USER, getTestUser());
+        protoConf.set(WorkflowAppService.HADOOP_UGI, getTestUser() + "," + getTestGroup());
+        protoConf.set(OozieClient.GROUP_NAME, getTestGroup());
+        protoConf.setStrings(WorkflowAppService.APP_LIB_PATH_LIST, appJarPath.toString(), appSoPath.toString());
+        injectKerberosInfo(protoConf);
+
+        WorkflowJobBean wf = createBaseWorkflow(protoConf, "action");
+        WorkflowActionBean action = (WorkflowActionBean) wf.getActions().get(0);
+        action.setType(ae.getType());
+        action.setConf(actionXml);
+
+        return new Context(wf, action);
+    }
+
+
+    protected RunningJob submitAction(Context context) throws Exception {
+        DistcpActionExecutor ae = new DistcpActionExecutor();
+
+        WorkflowAction action = context.getAction();
+
+        ae.prepareActionDir(getFileSystem(), context);
+        ae.submitLauncher(getFileSystem(), context, action);
+
+        String jobId = action.getExternalId();
+        String jobTracker = action.getTrackerUri();
+        String consoleUrl = action.getConsoleUrl();
+        assertNotNull(jobId);
+        assertNotNull(jobTracker);
+        assertNotNull(consoleUrl);
+
+        JobConf jobConf = new JobConf();
+        jobConf.set("mapred.job.tracker", jobTracker);
+        injectKerberosInfo(jobConf);
+        JobClient jobClient = new JobClient(jobConf);
+        final RunningJob runningJob = jobClient.getJob(JobID.forName(jobId));
+        assertNotNull(runningJob);
+        return runningJob;
+    }
+}

--- a/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
+++ b/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
@@ -14,43 +14,10 @@
  */
 package org.apache.oozie.action.hadoop;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.JobClient;
-import org.apache.hadoop.mapred.RunningJob;
-import org.apache.hadoop.mapred.JobID;
-import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.security.token.TokenIdentifier;
-import org.apache.hadoop.filecache.DistributedCache;
-import org.apache.hadoop.io.Text;
-import org.apache.oozie.WorkflowActionBean;
-import org.apache.oozie.WorkflowJobBean;
-import org.apache.oozie.action.ActionExecutor;
-import org.apache.oozie.action.ActionExecutorException;
-import org.apache.oozie.client.WorkflowAction;
-import org.apache.oozie.client.OozieClient;
-import org.apache.oozie.client.WorkflowJob;
-import org.apache.oozie.service.Services;
-import org.apache.oozie.service.UUIDService;
-import org.apache.oozie.service.WorkflowAppService;
-import org.apache.oozie.service.WorkflowStoreService;
-import org.apache.oozie.util.XConfiguration;
-import org.apache.oozie.util.XmlUtils;
-import org.apache.oozie.util.IOUtils;
-import org.apache.oozie.workflow.WorkflowApp;
-import org.apache.oozie.workflow.WorkflowInstance;
-import org.apache.oozie.workflow.WorkflowLib;
-import org.apache.oozie.workflow.lite.EndNodeDef;
-import org.apache.oozie.workflow.lite.LiteWorkflowApp;
-import org.apache.oozie.workflow.lite.StartNodeDef;
-import org.jdom.Element;
-
 import java.io.File;
-import java.io.OutputStream;
-import java.io.InputStream;
 import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,6 +25,39 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.filecache.DistributedCache;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobClient;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobID;
+import org.apache.hadoop.mapred.RunningJob;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.oozie.WorkflowActionBean;
+import org.apache.oozie.WorkflowJobBean;
+import org.apache.oozie.action.ActionExecutor;
+import org.apache.oozie.action.ActionExecutorException;
+import org.apache.oozie.client.OozieClient;
+import org.apache.oozie.client.WorkflowAction;
+import org.apache.oozie.client.WorkflowJob;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.service.UUIDService;
+import org.apache.oozie.service.WorkflowAppService;
+import org.apache.oozie.service.WorkflowStoreService;
+import org.apache.oozie.util.IOUtils;
+import org.apache.oozie.util.XConfiguration;
+import org.apache.oozie.util.XmlUtils;
+import org.apache.oozie.workflow.WorkflowApp;
+import org.apache.oozie.workflow.WorkflowInstance;
+import org.apache.oozie.workflow.WorkflowLib;
+import org.apache.oozie.workflow.lite.EndNodeDef;
+import org.apache.oozie.workflow.lite.LiteWorkflowApp;
+import org.apache.oozie.workflow.lite.StartNodeDef;
+import org.jdom.Element;
 
 public class TestJavaActionExecutor extends ActionExecutorTestCase {
 
@@ -250,7 +250,7 @@ public class TestJavaActionExecutor extends ActionExecutorTestCase {
 
     }
 
-    private Context createContext(String actionXml) throws Exception {
+    protected Context createContext(String actionXml) throws Exception {
         JavaActionExecutor ae = new JavaActionExecutor();
 
         Path appJarPath = new Path("lib/test.jar");
@@ -277,7 +277,7 @@ public class TestJavaActionExecutor extends ActionExecutorTestCase {
         return new Context(wf, action);
     }
 
-    private RunningJob submitAction(Context context) throws Exception {
+    protected RunningJob submitAction(Context context) throws Exception {
         JavaActionExecutor ae = new JavaActionExecutor();
 
         WorkflowAction action = context.getAction();

--- a/core/src/test/java/org/apache/oozie/command/wf/TestReRunCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/wf/TestReRunCommand.java
@@ -52,7 +52,7 @@ public class TestReRunCommand extends XFsTestCase {
 
         Path path = getFsTestCaseDir();
 
-        getFileSystem().mkdirs(new Path(path, "p2"));
+        getFileSystem().create(new Path(path, "p2"));
 
         final OozieClient wfClient = LocalOozie.getClient();
         Properties conf = wfClient.createConfiguration();

--- a/core/src/test/java/org/apache/oozie/command/wf/TestReRunXCommand.java
+++ b/core/src/test/java/org/apache/oozie/command/wf/TestReRunXCommand.java
@@ -52,7 +52,7 @@ public class TestReRunXCommand extends XFsTestCase {
 
         Path path = getFsTestCaseDir();
 
-        getFileSystem().mkdirs(new Path(path, "p2"));
+        getFileSystem().create(new Path(path, "p2"));
 
         final OozieClient wfClient = LocalOozie.getClient();
         Properties conf = wfClient.createConfiguration();
@@ -105,7 +105,7 @@ public class TestReRunXCommand extends XFsTestCase {
 
         Path path = getFsTestCaseDir();
 
-        getFileSystem().mkdirs(new Path(path, "p2"));
+        getFileSystem().create(new Path(path, "p2"));
 
         final OozieClient wfClient = LocalOozie.getClient();
         Properties conf = wfClient.createConfiguration();

--- a/core/src/test/java/org/apache/oozie/servlet/MockCoordinatorEngineService.java
+++ b/core/src/test/java/org/apache/oozie/servlet/MockCoordinatorEngineService.java
@@ -178,6 +178,14 @@ public class MockCoordinatorEngineService extends CoordinatorEngineService {
             writer.write(LOG);
         }
 
+        @Override
+        public void streamLog(String jobId, String logRetrievalScope, String logRetrievalType, Writer writer)
+                throws IOException, BaseEngineException {
+            did = RestConstants.JOB_SHOW_LOG;
+            validateCoordinatorIdx(jobId);
+            writer.write(LOG);
+        }
+
         private int validateCoordinatorIdx(String jobId) throws CoordinatorEngineException {
             int idx = -1;
             try {
@@ -273,6 +281,5 @@ public class MockCoordinatorEngineService extends CoordinatorEngineService {
         action.setCreatedConf(CONFIGURATION);
         return action;
     }
-
 
 }

--- a/core/src/test/java/org/apache/oozie/util/TestXLogReader.java
+++ b/core/src/test/java/org/apache/oozie/util/TestXLogReader.java
@@ -38,13 +38,22 @@ public class TestXLogReader extends XTestCase {
 
         FileWriter fw = new FileWriter(getTestCaseDir() + "/test.log");
         StringBuilder sb = new StringBuilder();
-        sb.append("2009-06-24 02:43:13,958 DEBUG _L1_:323 - USER[oozie] GROUP[-] TOKEN[-] APP[example-forkjoinwf] JOB[14-200904160239--example-forkjoinwf] ACTION[-] End workflow state change");
-        sb.append("\n2009-06-24 02:43:13,961  INFO _L2_:317 - USER[-] GROUP[-] TOKEN[-] APP[example-forkjoinwf] JOB[14-200904160239--example-forkjoinwf] ACTION[-] [org.apache.oozie.core.command.WorkflowRunnerCallable] released lock");
-        sb.append("\n2009-06-24 02:43:13,986  WARN _L3_:539 - USER[-] GROUP[-] TOKEN[-] APP[example-forkjoinwf] JOB[14-200904160239--example-forkjoinwf] ACTION[-] Use GenericOptionsParser for parsing the arguments. \n_L3A_Applications should implement Tool for the same. \n_L3B_Multi line test");
-        sb.append("\n2009-06-24 02:43:14,431  WARN _L4_:661 - No job jar file set.  User classes may not be found. See JobConf(Class) or JobConf#setJar(String).");
-        sb.append("\n2009-06-24 02:43:14,505  INFO _L5_:317 - USER[oozie] GROUP[oozie] TOKEN[-] APP[-] JOB[-] ACTION[-] Released Lock");
-        sb.append("\n2009-06-24 02:43:19,344 DEBUG _L6_:323 - USER[oozie] GROUP[oozie] TOKEN[MYtoken] APP[-] JOB[-] ACTION[-] Number of pending signals to check [0]");
-        sb.append("\n2009-06-24 02:43:29,151 DEBUG _L7_:323 - USER[-] GROUP[-] TOKEN[-] APP[-] JOB[-] ACTION[-] Number of pending actions [0] ");
+        sb.append("2009-06-24 02:43:13,958 DEBUG _L1_:323 - USER[oozie] GROUP[-] TOKEN[-] APP[example-forkjoinwf] "
+                + "JOB[14-200904160239--example-forkjoinwf] ACTION[-] End workflow state change");
+        sb.append("\n2009-06-24 02:43:13,961  INFO _L2_:317 - USER[-] GROUP[-] TOKEN[-] APP[example-forkjoinwf] "
+                + "JOB[14-200904160239--example-forkjoinwf] ACTION[-] "
+                + "[org.apache.oozie.core.command.WorkflowRunnerCallable] " + "released lock");
+        sb.append("\n2009-06-24 02:43:13,986  WARN _L3_:539 - USER[-] GROUP[-] TOKEN[-] APP[example-forkjoinwf] "
+                + "JOB[14-200904160239--example-forkjoinwf] ACTION[-] Use GenericOptionsParser for parsing "
+                + "the arguments. " + "\n_L3A_Applications should implement Tool for the same. \n_L3B_Multi line test");
+        sb.append("\n2009-06-24 02:43:14,431  WARN _L4_:661 - No job jar file set.  User classes may not be found. "
+                + "See JobConf(Class) or JobConf#setJar(String).");
+        sb.append("\n2009-06-24 02:43:14,505  INFO _L5_:317 - USER[oozie] GROUP[oozie] TOKEN[-] APP[-] JOB[-] "
+                + "ACTION[-] " + "Released Lock");
+        sb.append("\n2009-06-24 02:43:19,344 DEBUG _L6_:323 - USER[oozie] GROUP[oozie] TOKEN[MYtoken] APP[-] "
+                + "JOB[-] ACTION[-] Number of pending signals to check [0]");
+        sb.append("\n2009-06-24 02:43:29,151 DEBUG _L7_:323 - USER[-] GROUP[-] TOKEN[-] APP[-] JOB[-] ACTION[-] "
+                + "Number of pending actions [0] ");
 
         fw.write(sb.toString());
         fw.close();
@@ -57,5 +66,46 @@ public class TestXLogReader extends XTestCase {
         assertEquals(true, out[1].contains("_L3_"));
         assertEquals(true, out[2].contains("_L3A_"));
         assertEquals(true, out[3].contains("_L3B_"));
+    }
+
+    public void testProcessCoordinatorLogForActions() throws IOException {
+        XLogStreamer.Filter.reset();
+        XLogStreamer.Filter.defineParameter("USER");
+        XLogStreamer.Filter.defineParameter("GROUP");
+        XLogStreamer.Filter.defineParameter("TOKEN");
+        XLogStreamer.Filter.defineParameter("APP");
+        XLogStreamer.Filter.defineParameter("JOB");
+        XLogStreamer.Filter.defineParameter("ACTION");
+        XLogStreamer.Filter xf = new XLogStreamer.Filter();
+        xf.setParameter("JOB", "14-200904160239--example-C");
+        xf.setParameter("ACTION", "14-200904160239--example-C@1");
+        FileWriter fw = new FileWriter(getTestCaseDir() + "/test.log");
+        StringBuilder sb = new StringBuilder();
+        sb.append("2009-06-24 02:43:13,958 DEBUG _L1_:323 - USER[oozie] GROUP[-] TOKEN[-] APP[example-forkjoinwf] "
+                + "JOB[14-200904160239--example-C] ACTION[14-200904160239--example-C@1] End workflow state change");
+        sb.append("\n2009-06-24 02:43:13,961  INFO _L2_:317 - USER[-] GROUP[-] TOKEN[-] APP[example-forkjoinwf] "
+                + "JOB[14-200904160239--example-C] ACTION[14-200904160239--example-C@2] "
+                + "[org.apache.oozie.core.command.WorkflowRunnerCallable] released lock");
+        sb.append("\n2009-06-24 02:43:13,986  WARN _L3_:539 - USER[-] GROUP[-] TOKEN[-] APP[example-forkjoinwf] "
+                + "JOB[14-200904160239--example-C] ACTION[14-200904160239--example-C@2] Use GenericOptionsParser for "
+                + "parsing the arguments. \n_L3A_Applications should implement Tool for the same. \n_L3B_Multi line "
+                + "test");
+        sb.append("\n2009-06-24 02:43:14,431  WARN _L4_:661 - No job jar file set.  User classes may not be found. "
+                + "See JobConf(Class) or JobConf#setJar(String).");
+        sb.append("\n2009-06-24 02:43:14,505  INFO _L5_:317 - USER[oozie] GROUP[oozie] TOKEN[-] APP[-] "
+                + "JOB[14-200904160239--example-C] ACTION[14-200904160239--example-C@1] Released Lock");
+        sb.append("\n2009-06-24 02:43:19,344 DEBUG _L6_:323 - USER[oozie] GROUP[oozie] TOKEN[MYtoken] APP[-] "
+                + "JOB[-] ACTION[-] Number of pending signals to check [0]");
+        sb.append("\n2009-06-24 02:43:29,151 DEBUG _L7_:323 - USER[-] GROUP[-] TOKEN[-] APP[-] JOB[-] "
+                + "ACTION[-] Number of pending actions [0] ");
+        fw.write(sb.toString());
+        fw.close();
+        StringWriter sw = new StringWriter();
+        XLogReader lr = new XLogReader(new FileInputStream(getTestCaseDir() + "/test.log"), xf, sw);
+        lr.processLog();
+        String[] matches = sw.toString().split("\n");
+        assertEquals(2, matches.length);
+        assertEquals(true, matches[0].contains("_L1_"));
+        assertEquals(true, matches[1].contains("_L5_"));
     }
 }

--- a/docs/src/site/twiki/WorkflowFunctionalSpec.twiki
+++ b/docs/src/site/twiki/WorkflowFunctionalSpec.twiki
@@ -15,6 +15,9 @@ Author: Alejandro Abdelnur
 %TOC%
 
 ---++ Changelog
+---+++!! 2011AUG12
+
+   * #3.2.4 fs 'move' action characteristics updated, to allow for consistent source and target paths and existing target path only if directory
 ---+++!! 2011FEB19
 
    * #10, Update the doc to rerun from the failed node. 
@@ -980,7 +983,7 @@ Each file path must specify the file system URI, for move operations, the target
 
 IMPORTANT: All the commands within =fs= action do not happen atomically, if a =fs= action fails half way in the
 commands being executed, successfully executed commands are not rolled back. The =fs= action, before executing any
-command must check that source paths exist and target paths don't exist, thus failing before executing any command.
+command must check that source paths exist and target paths don't exist (constraint regarding target relaxed for the =move= action. See below for details), thus failing before executing any command.
 Therefore the validity of all paths specified in one =fs= action are evaluated before any of the file operation are
 executed. Thus there is less chance of an error occurring while the =fs= action executes.
 
@@ -1013,8 +1016,12 @@ deletes the directory.
 The =mkdir= command creates the specified directory, it creates all missing directories in the path. If the directory
 already exist it does a no-op.
 
-In the =move= command the =source= path must exist and the =target= path must not exist. The parent directory of the
- =target= path must exist, the =target= path must not specify the file system URI.
+In the =move= command the =source= path must exist. The following scenarios are addressed for a =move=:
+
+   * The file system URI(e.g. hdfs://{nameNode}) can be skipped in the =target= path. It is understood to be the same as that of the source. But if the target path does contain the system URI, it cannot be different than that of the source.
+   * The parent directory of the =target= path must exist
+   * For the =target= path, if it is a file, then it must not already exist. 
+   * However, if the =target= path is an already existing directory, the =move= action will place your =source= as a child of the =target= directory.
 
 The =chmod= command changes the permissions for the specified path. Permissions can be specified using the Unix Symbolic representation (e.g. -rwxrw-rw-) or an octal representation (755).
  When doing a =chmod= command on a directory, by default the command is applied to the directory and the files one level within the directory. To apply the =chmod= command to the directory, without affecting the files within it, the =dir-files= attribute must be set to =false=.

--- a/release-log.txt
+++ b/release-log.txt
@@ -2,9 +2,10 @@
 
 OOZIE-5 Log retrieval for a Coordinator job with large number or actions 
 OOZIE-7 Ability to view the log information corresponding to particular coordinator actions
+OOZIE-11  Adding Distcp Action.  
 OOZIE-6 Custom filters option and User information column added to Coordinator jobs section of Oozie Web Console
 OOZIE-124 Update documentation for job-type in WS API
-OOZIE-81 Add an email action to Oozie
+OOZIE-81  Add an email action to Oozie
 OOZIE-113 merge changes for OOZIE-101 to ActionEndXCommand 
 OOZIE-112 workflow kill node message is not resolved and set it to action error message
 OOZIE-111 adjust configuration for DBCP data source 

--- a/release-log.txt
+++ b/release-log.txt
@@ -2,6 +2,7 @@
 
 OOZIE-5 Log retrieval for a Coordinator job with large number or actions 
 OOZIE-7 Ability to view the log information corresponding to particular coordinator actions
+OOZIE-6 Custom filters option and User information column added to Coordinator jobs section of Oozie Web Console
 OOZIE-124 Update documentation for job-type in WS API
 OOZIE-81 Add an email action to Oozie
 OOZIE-113 merge changes for OOZIE-101 to ActionEndXCommand 

--- a/release-log.txt
+++ b/release-log.txt
@@ -18,6 +18,7 @@ OOZIE-100 escape characters for xml when create dag evaluator
 OOZIE-98 parametrization of 'name' attribute in workflow/coordinator/bundle
 OOZIE-106 add new queue class to iterate next callable when current callable type has reached max concorrency
 OOZIE-108 Upgrade pom version to 3.1.0.
+OOZIE-133 Fs 'move' action made consistent and able to have existing target dir
 
 -- Oozie 3.0.2 release
 

--- a/release-log.txt
+++ b/release-log.txt
@@ -2,6 +2,7 @@
 
 OOZIE-5 Log retrieval for a Coordinator job with large number or actions 
 OOZIE-7 Ability to view the log information corresponding to particular coordinator actions
+OOZIE-18 Option to view Workflow job details from Coordinator job detail popup
 OOZIE-11  Adding Distcp Action.  
 OOZIE-6 Custom filters option and User information column added to Coordinator jobs section of Oozie Web Console
 OOZIE-124 Update documentation for job-type in WS API

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,7 @@
 -- Oozie 3.1.0 release
 
+OOZIE-5 Log retrieval for a Coordinator job with large number or actions 
+OOZIE-7 Ability to view the log information corresponding to particular coordinator actions
 OOZIE-124 Update documentation for job-type in WS API
 OOZIE-81 Add an email action to Oozie
 OOZIE-113 merge changes for OOZIE-101 to ActionEndXCommand 

--- a/webapp/src/main/webapp/oozie-console.js
+++ b/webapp/src/main/webapp/oozie-console.js
@@ -697,11 +697,17 @@ function coordJobDetailsPopup(response, request) {
         bbar: getPagingBar(jobActionStatus),
         listeners: {
             cellclick: {
-                fn: showCoordActionContextMenu
+                fn: showWorkflowPopup
             }
         }
 
     });
+    function showWorkflowPopup(thisGrid, rowIndex, cellIndex, e) {
+        var jobContextMenu = new Ext.menu.Menu('taskContext');
+        var actionStatus = thisGrid.store.data.items[rowIndex].data;
+        var workflowId = actionStatus["externalId"];
+        jobDetailsGridWindow(workflowId);
+    }
     // alert("Coordinator PopUP 4 inside coordDetailsPopup ");
     function showCoordActionContextMenu(thisGrid, rowIndex, cellIndex, e) {
         var jobContextMenu = new Ext.menu.Menu('taskContext');

--- a/webapp/src/main/webapp/oozie-console.js
+++ b/webapp/src/main/webapp/oozie-console.js
@@ -593,6 +593,12 @@ function coordJobDetailsPopup(response, request) {
             width: 200,
             value: jobDetails["status"]
         }, {
+            fieldLabel: 'User',
+            editable: false,
+            name: 'status',
+            width: 200,
+            value: jobDetails["user"]
+	}, {
             fieldLabel: 'Frequency',
             editable: false,
             name: 'frequency',
@@ -873,7 +879,7 @@ function bundleJobDetailsPopup(response, request) {
     var bundleJobName = jobDetails["bundleJobName"];
     var jobActionStatus = new Ext.data.JsonStore({
         data: jobDetails["bundleCoordJobs"],
-        fields: ['coordJobId', 'coordJobName', 'coordJobPath', 'frequency', 'timeUnit', 'nextMaterializedTime', 'status', 'startTime', 'endTime', 'pauseTime']
+        fields: ['coordJobId', 'coordJobName', 'coordJobPath', 'frequency', 'timeUnit', 'nextMaterializedTime', 'status', 'startTime', 'endTime', 'pauseTime','user']
     });
 
     var formFieldSet = new Ext.form.FieldSet({
@@ -967,6 +973,11 @@ function bundleJobDetailsPopup(response, request) {
             width: 80,
             sortable: true,
             dataIndex: 'status'
+        }, {
+            header: "User",
+            width: 80,
+            sortable: true,
+            dataIndex: 'user'
         }, {
             header: "Frequency",
             width: 80,
@@ -1123,7 +1134,7 @@ var coord_jobs_store = new Ext.data.JsonStore({
     totalProperty: 'total',
     autoLoad: true,
     root: 'coordinatorjobs',
-    fields: ['coordJobId', 'coordJobName', 'status', 'frequency', 'timeUnit', 'startTime', 'nextMaterializedTime'],
+    fields: ['coordJobId', 'coordJobName', 'status', 'user', 'frequency', 'timeUnit', 'startTime', 'nextMaterializedTime'],
     proxy: new Ext.data.HttpProxy({
         url: getOozieBase() + 'jobs'
     })
@@ -1225,6 +1236,15 @@ var refreshDoneJobsAction = new Ext.Action({
     }
 });
 
+var refreshCoordCustomJobsAction = new Ext.Action({
+    text: 'status=KILLED',
+    handler: function() {
+        coord_jobs_store.baseParams.filter = this.text;
+        coord_jobs_store.reload();
+    }
+});
+
+
 var refreshCoordActiveJobsAction = new Ext.Action({
     text: 'Active Jobs',
     handler: function() {
@@ -1324,6 +1344,20 @@ var changeFilterAction = new Ext.Action({
         });
     }
 });
+
+var changeCoordFilterAction = new Ext.Action({
+    text: 'Custom Filter',
+    handler: function() {
+        Ext.Msg.prompt('Filter Criteria', 'Filter text:', function(btn, text) {
+            if (btn == 'ok' && text) {
+                refreshCoordCustomJobsAction.setText(text);
+                coord_jobs_store.baseParams.filter = text;
+                coord_jobs_store.reload();
+            }
+        });
+    }
+});
+
 
 var getSupportedVersions = new Ext.Action({
     text: 'Checking server for supported versions...',
@@ -1651,7 +1685,12 @@ function initConsole() {
             header: "Status",
             width: 80,
             sortable: true,
-            dataIndex: 'status'
+            dataIndex: 'status'        
+	}, {
+            header: "User",
+            width: 80,
+            sortable: true,
+            dataIndex: 'user'
         }, {
             header: "frequency",
             width: 70,
@@ -1684,8 +1723,10 @@ function initConsole() {
             handler: function() {
                 coord_jobs_store.reload();
             }
-        }, refreshCoordAllJobsAction, refreshCoordActiveJobsAction, refreshCoordDoneJobsAction,
-            {
+        }, refreshCoordAllJobsAction, refreshCoordActiveJobsAction, refreshCoordDoneJobsAction,{
+            text: 'Custom Filter',
+            menu: [refreshCoordCustomJobsAction, changeCoordFilterAction, helpFilterAction ]
+        },  {
                 xtype: 'tbfill'
             }, checkStatus, serverVersion],
         title: 'Coordinator Jobs',


### PR DESCRIPTION
Option to pull the log for specific coordinator actions of a coordinator job has been added. This makes it easier to analyze the log when an action re-run is necessary. 

At present the parts of response sent from the server are appended and finally printed. Fix has been made to print the response now and then by getting the commandLine's PrintStream.
