### PR TITLE
CLOSES OOZIE-17 Group column for Coordinate jobs in Oozie Web Console

### DIFF
--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.1.0 release
 
+OOZIE-17 Group column for coordinator jobs in Oozie Web Console
 OOZIE-124 Update documentation for job-type in WS API
 OOZIE-81 Add an email action to Oozie
 OOZIE-113 merge changes for OOZIE-101 to ActionEndXCommand 

--- a/webapp/src/main/webapp/oozie-console.js
+++ b/webapp/src/main/webapp/oozie-console.js
@@ -593,6 +593,18 @@ function coordJobDetailsPopup(response, request) {
             width: 200,
             value: jobDetails["status"]
         }, {
+            fieldLabel: 'User',
+            editable: false,
+            name: 'user',
+            width: 200,
+            value: jobDetails["user"]
+	}, {
+            fieldLabel: 'Group',
+            editable: false,
+            name: 'group',
+            width: 200,
+            value: jobDetails["group"]
+	}, {
             fieldLabel: 'Frequency',
             editable: false,
             name: 'frequency',
@@ -873,7 +885,7 @@ function bundleJobDetailsPopup(response, request) {
     var bundleJobName = jobDetails["bundleJobName"];
     var jobActionStatus = new Ext.data.JsonStore({
         data: jobDetails["bundleCoordJobs"],
-        fields: ['coordJobId', 'coordJobName', 'coordJobPath', 'frequency', 'timeUnit', 'nextMaterializedTime', 'status', 'startTime', 'endTime', 'pauseTime']
+        fields: ['coordJobId', 'coordJobName', 'coordJobPath', 'frequency', 'timeUnit', 'nextMaterializedTime', 'status', 'startTime', 'endTime', 'pauseTime','user','group']
     });
 
     var formFieldSet = new Ext.form.FieldSet({
@@ -967,6 +979,16 @@ function bundleJobDetailsPopup(response, request) {
             width: 80,
             sortable: true,
             dataIndex: 'status'
+        }, {
+            header: "User",
+            width: 80,
+            sortable: true,
+            dataIndex: 'user'
+        }, {
+            header: "Group",
+            width: 80,
+            sortable: true,
+            dataIndex: 'group'
         }, {
             header: "Frequency",
             width: 80,
@@ -1123,7 +1145,7 @@ var coord_jobs_store = new Ext.data.JsonStore({
     totalProperty: 'total',
     autoLoad: true,
     root: 'coordinatorjobs',
-    fields: ['coordJobId', 'coordJobName', 'status', 'frequency', 'timeUnit', 'startTime', 'nextMaterializedTime'],
+    fields: ['coordJobId', 'coordJobName', 'status', 'user', 'group', 'frequency', 'timeUnit', 'startTime', 'nextMaterializedTime'],
     proxy: new Ext.data.HttpProxy({
         url: getOozieBase() + 'jobs'
     })
@@ -1225,6 +1247,15 @@ var refreshDoneJobsAction = new Ext.Action({
     }
 });
 
+var refreshCoordCustomJobsAction = new Ext.Action({
+    text: 'status=KILLED',
+    handler: function() {
+        coord_jobs_store.baseParams.filter = this.text;
+        coord_jobs_store.reload();
+    }
+});
+
+
 var refreshCoordActiveJobsAction = new Ext.Action({
     text: 'Active Jobs',
     handler: function() {
@@ -1324,6 +1355,20 @@ var changeFilterAction = new Ext.Action({
         });
     }
 });
+
+var changeCoordFilterAction = new Ext.Action({
+    text: 'Custom Filter',
+    handler: function() {
+        Ext.Msg.prompt('Filter Criteria', 'Filter text:', function(btn, text) {
+            if (btn == 'ok' && text) {
+                refreshCoordCustomJobsAction.setText(text);
+                coord_jobs_store.baseParams.filter = text;
+                coord_jobs_store.reload();
+            }
+        });
+    }
+});
+
 
 var getSupportedVersions = new Ext.Action({
     text: 'Checking server for supported versions...',
@@ -1651,7 +1696,17 @@ function initConsole() {
             header: "Status",
             width: 80,
             sortable: true,
-            dataIndex: 'status'
+            dataIndex: 'status'        
+	}, {
+            header: "User",
+            width: 80,
+            sortable: true,
+            dataIndex: 'user'
+        }, {
+            header: "Group",
+            width: 80,
+            sortable: true,
+            dataIndex: 'group'
         }, {
             header: "frequency",
             width: 70,
@@ -1684,8 +1739,10 @@ function initConsole() {
             handler: function() {
                 coord_jobs_store.reload();
             }
-        }, refreshCoordAllJobsAction, refreshCoordActiveJobsAction, refreshCoordDoneJobsAction,
-            {
+        }, refreshCoordAllJobsAction, refreshCoordActiveJobsAction, refreshCoordDoneJobsAction,{
+            text: 'Custom Filter',
+            menu: [refreshCoordCustomJobsAction, changeCoordFilterAction, helpFilterAction ]
+        },  {
                 xtype: 'tbfill'
             }, checkStatus, serverVersion],
         title: 'Coordinator Jobs',


### PR DESCRIPTION
Adding group column to the Coordinators jobs in Oozie Web Console enables users to distinguish the jobs corresponding to a particular user.
