### PR TITLE
CLOSES OOZIE-17 Group column for Coordinator jobs in Oozie Web Console

### DIFF
--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.1.0 release
 
+OOZIE-17 Group column for Coordinator jobs in Oozie Web Console
 OOZIE-11  Adding Distcp Action.  
 OOZIE-6 Custom filters option and User information column added to Coordinator jobs section of Oozie Web Console
 OOZIE-124 Update documentation for job-type in WS API

--- a/webapp/src/main/webapp/oozie-console.js
+++ b/webapp/src/main/webapp/oozie-console.js
@@ -595,10 +595,16 @@ function coordJobDetailsPopup(response, request) {
         }, {
             fieldLabel: 'User',
             editable: false,
-            name: 'status',
+            name: 'user',
             width: 200,
             value: jobDetails["user"]
 	}, {
+            fieldLabel: 'Group',
+            editable: false,
+            name: 'group',
+            width: 200,
+            value: jobDetails["group"]
+        }, {
             fieldLabel: 'Frequency',
             editable: false,
             name: 'frequency',
@@ -879,7 +885,7 @@ function bundleJobDetailsPopup(response, request) {
     var bundleJobName = jobDetails["bundleJobName"];
     var jobActionStatus = new Ext.data.JsonStore({
         data: jobDetails["bundleCoordJobs"],
-        fields: ['coordJobId', 'coordJobName', 'coordJobPath', 'frequency', 'timeUnit', 'nextMaterializedTime', 'status', 'startTime', 'endTime', 'pauseTime','user']
+        fields: ['coordJobId', 'coordJobName', 'coordJobPath', 'frequency', 'timeUnit', 'nextMaterializedTime', 'status', 'startTime', 'endTime', 'pauseTime','user','group']
     });
 
     var formFieldSet = new Ext.form.FieldSet({
@@ -978,6 +984,11 @@ function bundleJobDetailsPopup(response, request) {
             width: 80,
             sortable: true,
             dataIndex: 'user'
+        }, {
+            header: "Group",
+            width: 80,
+            sortable: true,
+            dataIndex: 'group'
         }, {
             header: "Frequency",
             width: 80,
@@ -1134,7 +1145,7 @@ var coord_jobs_store = new Ext.data.JsonStore({
     totalProperty: 'total',
     autoLoad: true,
     root: 'coordinatorjobs',
-    fields: ['coordJobId', 'coordJobName', 'status', 'user', 'frequency', 'timeUnit', 'startTime', 'nextMaterializedTime'],
+    fields: ['coordJobId', 'coordJobName', 'status', 'user', 'group', 'frequency', 'timeUnit', 'startTime', 'nextMaterializedTime'],
     proxy: new Ext.data.HttpProxy({
         url: getOozieBase() + 'jobs'
     })
@@ -1691,6 +1702,11 @@ function initConsole() {
             width: 80,
             sortable: true,
             dataIndex: 'user'
+        }, {
+            header: "Group",
+            width: 80,
+            sortable: true,
+            dataIndex: 'group'
         }, {
             header: "frequency",
             width: 70,


### PR DESCRIPTION
Adding group column to the Coordinators jobs in Oozie Web Console enables users to distinguish the jobs corresponding to a particular user.
