### PR TITLE
Closes OOZIE-9 (Apache) Launcher job should be able to run in different q

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
@@ -378,10 +378,13 @@ public class JavaActionExecutor extends ActionExecutor {
         return e.getTextTrim();
     }
 
+    private static final String QUEUE_NAME = "mapred.job.queue.name";
+    private static final String OOZIE_LAUNCHER_QUEUE_NAME = "oozie.launcher.mapred.job.queue.name";
+
     private static final Set<String> SPECIAL_PROPERTIES = new HashSet<String>();
 
     static {
-        SPECIAL_PROPERTIES.add("mapred.job.queue.name");
+        SPECIAL_PROPERTIES.add(QUEUE_NAME);
         SPECIAL_PROPERTIES.add("mapreduce.jobtracker.kerberos.principal");
         SPECIAL_PROPERTIES.add("dfs.namenode.kerberos.principal");
     }
@@ -444,7 +447,10 @@ public class JavaActionExecutor extends ActionExecutor {
             for (String name : SPECIAL_PROPERTIES) {
                 String value = actionConf.get(name);
                 if (value != null) {
-                    launcherJobConf.set(name, value);
+                    if (!name.equals(QUEUE_NAME) ||
+                        (name.equals(QUEUE_NAME) && launcherJobConf.get(OOZIE_LAUNCHER_QUEUE_NAME) == null)) {
+                        launcherJobConf.set(name, value);
+                    }
                 }
             }
 

--- a/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
+++ b/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
@@ -248,6 +248,40 @@ public class TestJavaActionExecutor extends ActionExecutorTestCase {
 
         assertTrue(getFileSystem().exists(new Path(context.getActionDir(), LauncherMapper.ACTION_CONF_XML)));
 
+        actionXml = XmlUtils.parseXml("<java>" + "<job-tracker>" + getJobTrackerUri() + "</job-tracker>" +
+                "<name-node>" + getNameNodeUri() + "</name-node> <configuration>" +
+                "<property><name>mapred.job.queue.name</name><value>AQ</value></property>" +
+                "</configuration>" + "<main-class>MAIN-CLASS</main-class>" +
+                "</java>");
+        actionConf = ae.createBaseHadoopConf(context, actionXml);
+        ae.setupActionConf(actionConf, context, actionXml, appPath);
+        conf = ae.createLauncherConf(getFileSystem(), context, action, actionXml, actionConf);
+        assertEquals("AQ", conf.get("mapred.job.queue.name"));
+        assertEquals("AQ", actionConf.get("mapred.job.queue.name"));
+
+        actionXml = XmlUtils.parseXml("<java>" + "<job-tracker>" + getJobTrackerUri() + "</job-tracker>" +
+                "<name-node>" + getNameNodeUri() + "</name-node> <configuration>" +
+                "<property><name>oozie.launcher.mapred.job.queue.name</name><value>LQ</value></property>" +
+                "</configuration>" + "<main-class>MAIN-CLASS</main-class>" +
+                "</java>");
+        actionConf = ae.createBaseHadoopConf(context, actionXml);
+        ae.setupActionConf(actionConf, context, actionXml, appPath);
+        conf = ae.createLauncherConf(getFileSystem(), context, action, actionXml, actionConf);
+        assertEquals("LQ", conf.get("mapred.job.queue.name"));
+
+        actionXml = XmlUtils.parseXml("<java>" + "<job-tracker>" + getJobTrackerUri() + "</job-tracker>" +
+                "<name-node>" + getNameNodeUri() + "</name-node> <configuration>" +
+                "<property><name>oozie.launcher.mapred.job.queue.name</name><value>LQ</value></property>" +
+                "<property><name>mapred.job.queue.name</name><value>AQ</value></property>" +
+                "</configuration>" + "<main-class>MAIN-CLASS</main-class>" +
+                "</java>");
+        actionConf = ae.createBaseHadoopConf(context, actionXml);
+        ae.setupActionConf(actionConf, context, actionXml, appPath);
+        conf = ae.createLauncherConf(getFileSystem(), context, action, actionXml, actionConf);
+        assertEquals("LQ", conf.get("mapred.job.queue.name"));
+        assertEquals("AQ", actionConf.get("mapred.job.queue.name"));
+
+
     }
 
     protected Context createContext(String actionXml) throws Exception {

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.1.0 release
 
+OOZIE-9 (Apache) Launcher job should be able to run in different queue than job itself
 OOZIE-11  Adding Distcp Action.  
 OOZIE-6 Custom filters option and User information column added to Coordinator jobs section of Oozie Web Console
 OOZIE-124 Update documentation for job-type in WS API


### PR DESCRIPTION
Closes OOZIE-9 (Apache) Launcher job should be able to run in different queue than job itself
