### PR TITLE
Aoozie 9b2.3

### DIFF
--- a/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
@@ -376,10 +376,13 @@ public class JavaActionExecutor extends ActionExecutor {
         return e.getTextTrim();
     }
 
+    private static final String QUEUE_NAME = "mapred.job.queue.name";
+    private static final String OOZIE_LAUNCHER_QUEUE_NAME = "oozie.launcher.mapred.job.queue.name";
+
     private static final Set<String> SPECIAL_PROPERTIES = new HashSet<String>();
 
     static {
-        SPECIAL_PROPERTIES.add("mapred.job.queue.name");
+        SPECIAL_PROPERTIES.add(QUEUE_NAME);
         SPECIAL_PROPERTIES.add("mapreduce.jobtracker.kerberos.principal");
         SPECIAL_PROPERTIES.add("dfs.namenode.kerberos.principal");
     }
@@ -438,7 +441,10 @@ public class JavaActionExecutor extends ActionExecutor {
             for (String name : SPECIAL_PROPERTIES) {
                 String value = actionConf.get(name);
                 if (value != null) {
-                    launcherJobConf.set(name, value);
+                    if (!name.equals(QUEUE_NAME) ||
+                        (name.equals(QUEUE_NAME) && launcherJobConf.get(OOZIE_LAUNCHER_QUEUE_NAME) == null)) {
+                        launcherJobConf.set(name, value);
+                    }
                 }
             }
 

--- a/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
+++ b/core/src/test/java/org/apache/oozie/action/hadoop/TestJavaActionExecutor.java
@@ -226,6 +226,40 @@ public class TestJavaActionExecutor extends ActionExecutorTestCase {
 
         assertTrue(getFileSystem().exists(new Path(context.getActionDir(), LauncherMapper.ACTION_CONF_XML)));
 
+        actionXml = XmlUtils.parseXml("<java>" + "<job-tracker>" + getJobTrackerUri() + "</job-tracker>" +
+                "<name-node>" + getNameNodeUri() + "</name-node> <configuration>" +
+                "<property><name>mapred.job.queue.name</name><value>AQ</value></property>" +
+                "</configuration>" + "<main-class>MAIN-CLASS</main-class>" +
+                "</java>");
+        actionConf = ae.createBaseHadoopConf(context, actionXml);
+        ae.setupActionConf(actionConf, context, actionXml, appPath);
+        conf = ae.createLauncherConf(context, action, actionXml, actionConf);
+        assertEquals("AQ", conf.get("mapred.job.queue.name"));
+        assertEquals("AQ", actionConf.get("mapred.job.queue.name"));
+
+        actionXml = XmlUtils.parseXml("<java>" + "<job-tracker>" + getJobTrackerUri() + "</job-tracker>" +
+                "<name-node>" + getNameNodeUri() + "</name-node> <configuration>" +
+                "<property><name>oozie.launcher.mapred.job.queue.name</name><value>LQ</value></property>" +
+                "</configuration>" + "<main-class>MAIN-CLASS</main-class>" +
+                "</java>");
+        actionConf = ae.createBaseHadoopConf(context, actionXml);
+        ae.setupActionConf(actionConf, context, actionXml, appPath);
+        conf = ae.createLauncherConf(context, action, actionXml, actionConf);
+        assertEquals("LQ", conf.get("mapred.job.queue.name"));
+
+        actionXml = XmlUtils.parseXml("<java>" + "<job-tracker>" + getJobTrackerUri() + "</job-tracker>" +
+                "<name-node>" + getNameNodeUri() + "</name-node> <configuration>" +
+                "<property><name>oozie.launcher.mapred.job.queue.name</name><value>LQ</value></property>" +
+                "<property><name>mapred.job.queue.name</name><value>AQ</value></property>" +
+                "</configuration>" + "<main-class>MAIN-CLASS</main-class>" +
+                "</java>");
+        actionConf = ae.createBaseHadoopConf(context, actionXml);
+        ae.setupActionConf(actionConf, context, actionXml, appPath);
+        conf = ae.createLauncherConf(context, action, actionXml, actionConf);
+        assertEquals("LQ", conf.get("mapred.job.queue.name"));
+        assertEquals("AQ", actionConf.get("mapred.job.queue.name"));
+
+
     }
 
     private Context createContext(String actionXml) throws Exception {

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 2.3.2 release
 
+OOZIE-9 (Apache) Launcher job should be able to run in different queue than job itself
 OOZIE-81 Add an email action to Oozie
 OOZIE-101 ${wf:lastErrorNode()} is not set when an action ends in error
 OOZIE-99 action errorMessage is not being set


### PR DESCRIPTION
Closes OOZIE-9 (Apache) Launcher job should be able to run in different queue than job itself

backport for 2.3
