### PR TITLE
Closes OOZIE-27 oozie job info list actions by action number

### DIFF
--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -760,7 +762,15 @@ public class OozieCLI {
         System.out.println("App Path : " + maskIfNull(coordJob.getAppPath()));
         System.out.println("Status   : " + coordJob.getStatus());
         System.out.println(RULER);
+        
+        sortActionsByActionNumber(actions, new Comparator<CoordinatorAction>() {
 
+			@Override
+			public int compare(CoordinatorAction action1, CoordinatorAction action2) {
+				return action1.getActionNumber() - action2.getActionNumber();
+			}
+		});
+        
         if (verbose) {
             System.out.println("ID" + VERBOSE_DELIMITER + "Action Number" + VERBOSE_DELIMITER + "Console URL"
                     + VERBOSE_DELIMITER + "Error Code" + VERBOSE_DELIMITER + "Error Message" + VERBOSE_DELIMITER
@@ -800,7 +810,12 @@ public class OozieCLI {
         }
     }
 
-    private void printBundleJob(BundleJob bundleJob, boolean localtime, boolean verbose) {
+    public void sortActionsByActionNumber(List<CoordinatorAction> actions,
+			Comparator<CoordinatorAction> comparator) {
+		Collections.sort(actions, comparator);
+	}
+
+	private void printBundleJob(BundleJob bundleJob, boolean localtime, boolean verbose) {
         System.out.println("Job ID : " + bundleJob.getId());
 
         System.out.println(RULER);

--- a/client/src/test/java/org/apache/oozie/cli/TestOozieCLI.java
+++ b/client/src/test/java/org/apache/oozie/cli/TestOozieCLI.java
@@ -1,0 +1,128 @@
+package org.apache.oozie.cli;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.oozie.client.CoordinatorAction;
+import junit.framework.TestCase;
+
+public class TestOozieCLI extends TestCase {
+	
+	private CoordinatorAction createDummyCoordinatorAction(final String id, final int actionNumber) {
+		return new CoordinatorAction() {
+			
+			@Override
+			public void setErrorMessage(String errorMessage) {
+			}
+			
+			@Override
+			public void setErrorCode(String errorCode) {
+			}
+			
+			@Override
+			public String getTrackerUri() {
+				return null;
+			}
+			
+			@Override
+			public Status getStatus() {
+				return null;
+			}
+			
+			@Override
+			public String getRunConf() {
+				return null;
+			}
+			
+			@Override
+			public Date getNominalTime() {
+				return null;
+			}
+			
+			@Override
+			public String getMissingDependencies() {
+				return null;
+			}
+			
+			@Override
+			public Date getLastModifiedTime() {
+				return null;
+			}
+			
+			@Override
+			public String getJobId() {
+				return null;
+			}
+			
+			@Override
+			public String getId() {
+				return id;
+			}
+			
+			@Override
+			public String getExternalStatus() {
+				return null;
+			}
+			
+			@Override
+			public String getExternalId() {
+				return null;
+			}
+			
+			@Override
+			public String getErrorMessage() {
+				return null;
+			}
+			
+			@Override
+			public String getErrorCode() {
+				return null;
+			}
+			
+			@Override
+			public Date getCreatedTime() {
+				return null;
+			}
+			
+			@Override
+			public String getCreatedConf() {
+				return null;
+			}
+			
+			@Override
+			public String getConsoleUrl() {
+				return null;
+			}
+			
+			@Override
+			public int getActionNumber() {
+				return actionNumber;
+			}
+		}; 
+	}
+	
+	public void testSortingActionsByActionNumber() throws Exception {
+		List<CoordinatorAction> actions = new ArrayList<CoordinatorAction>();
+		actions.add(createDummyCoordinatorAction("0000426-100422050556688-oozie-marc-C@82", 82));
+		actions.add(createDummyCoordinatorAction("0000426-100422050556688-oozie-marc-C@58", 58));
+		actions.add(createDummyCoordinatorAction("0000426-100422050556688-oozie-marc-C@30", 30));
+		actions.add(createDummyCoordinatorAction("0000426-100422050556688-oozie-marc-C@5", 5));
+		actions.add(createDummyCoordinatorAction("0000426-100422050556688-oozie-marc-C@18", 18));
+		
+		new OozieCLI().sortActionsByActionNumber(actions, new Comparator<CoordinatorAction>() {
+
+			@Override
+			public int compare(CoordinatorAction action1, CoordinatorAction action2) {
+				return action1.getActionNumber() - action2.getActionNumber();
+			}
+		});
+		
+		assertEquals(5, actions.get(0).getActionNumber());
+		assertEquals(18, actions.get(1).getActionNumber());
+		assertEquals(30, actions.get(2).getActionNumber());
+		assertEquals(58, actions.get(3).getActionNumber());
+		assertEquals(82, actions.get(4).getActionNumber());
+	}
+}


### PR DESCRIPTION
On issuing the job info command (below) through the oozie command line, the coordinator actions are currently being listed in random order (probably based on the order they appear in mysql table). They should be listed in an order based on their action numbers.

$ oozie job -info 0000426-100422050556688-oozie-marc-C -oozie 
