### PR TITLE
[3.1.0] Closes OOZIE-28 update coordinator name to coord job at loadstate of coor

### DIFF
--- a/core/src/main/java/org/apache/oozie/command/coord/CoordSubmitXCommand.java
+++ b/core/src/main/java/org/apache/oozie/command/coord/CoordSubmitXCommand.java
@@ -988,6 +988,10 @@ public class CoordSubmitXCommand extends SubmitTransitionXCommand {
             logInfo.setParameter(DagXLogInfoService.JOB, this.bundleId);
             LogUtils.setLogInfo(logInfo);
         }
+        if (this.coordName != null) {
+            // this coord job is created from bundle
+            coordJob.setAppName(this.coordName);
+        }
         setJob(coordJob);
 
     }

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.1.0 release
 
+OOZIE-28 update coordinator name to coord job at loadstate of coord-submit to avoid exception of bundle-status-update 
 OOZIE-22 (Apache) Add support PostgreSQL
 OOZIE-10 add user-retry in workflow action
 OOZIE-123 CoordKillXCommand command uniqueness and increase priority


### PR DESCRIPTION
Closes OOZIE-28 update coordinator name to coord job at loadstate of coord-submit to avoid exception of bundle-status-update
