### PR TITLE
2.3.2release

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.yahoo.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.2</version>
     </parent>
     <artifactId>oozie-client</artifactId>
     <description>Oozie Client</description>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.yahoo.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.2</version>
     </parent>
     <artifactId>oozie-core</artifactId>
     <description>Oozie Core</description>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.yahoo.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.2</version>
     </parent>
     <!-- calling the artifact oozie to the generated distro file is oozie- -->
     <artifactId>oozie</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.yahoo.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.2</version>
     </parent>
     <artifactId>oozie-docs</artifactId>
     <description>Oozie Docs</description>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.yahoo.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.2</version>
     </parent>
     <artifactId>oozie-examples</artifactId>
     <description>Oozie Examples</description>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.yahoo.oozie</groupId>
     <artifactId>oozie-main</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.2</version>
     <description>Oozie Main</description>
     <name>Oozie Main</name>
     <packaging>pom</packaging>
@@ -129,39 +129,39 @@
             <dependency>
                 <groupId>com.yahoo.oozie</groupId>
                 <artifactId>oozie-client</artifactId>
-                <version>2.3.2-SNAPSHOT</version>
+                <version>2.3.2</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.oozie</groupId>
                 <artifactId>oozie-core</artifactId>
-                <version>2.3.2-SNAPSHOT</version>
+                <version>2.3.2</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.oozie</groupId>
                 <artifactId>oozie-core</artifactId>
                 <classifier>tests</classifier>
-                <version>2.3.2-SNAPSHOT</version>
+                <version>2.3.2</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.oozie</groupId>
                 <artifactId>oozie-examples</artifactId>
-                <version>2.3.2-SNAPSHOT</version>
+                <version>2.3.2</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.oozie</groupId>
                 <artifactId>oozie-sharelib</artifactId>
-                <version>2.3.2-SNAPSHOT</version>
+                <version>2.3.2</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.oozie</groupId>
                 <artifactId>oozie-docs</artifactId>
-                <version>2.3.2-SNAPSHOT</version>
+                <version>2.3.2</version>
                 <type>war</type>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.oozie</groupId>
                 <artifactId>oozie-webapp</artifactId>
-                <version>2.3.2-SNAPSHOT</version>
+                <version>2.3.2</version>
                 <type>war</type>
             </dependency>
             

--- a/sharelib/pom.xml
+++ b/sharelib/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.yahoo.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.2</version>
     </parent>
     <artifactId>oozie-sharelib</artifactId>
     <description>Oozie Share Lib</description>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.yahoo.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.2</version>
     </parent>
     <artifactId>oozie-webapp</artifactId>
     <description>Oozie WebApp</description>


### PR DESCRIPTION
Upgrading version for 2.3.2 release. Not opening an Apache JIRA because this is not an Apache release.

After applying this PR, the corresponding release tag must be created
