### PR TITLE
Closes OOZIE-32 (Apache) Oozie CLI does not have WF 0.2 schema registered

### DIFF
--- a/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
+++ b/client/src/main/java/org/apache/oozie/cli/OozieCLI.java
@@ -1213,8 +1213,10 @@ public class OozieCLI {
         if (file.exists()) {
             try {
                 List<StreamSource> sources = new ArrayList<StreamSource>();
-                sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
-                        "oozie-workflow-0.1.xsd")));
+              sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                      "oozie-workflow-0.1.xsd")));
+              sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                      "oozie-workflow-0.2.xsd")));
                 sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(
                         "email-action-0.1.xsd")));
                 sources.add(new StreamSource(Thread.currentThread().getContextClassLoader().getResourceAsStream(

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.1.0 release
 
+OOZIE-32 (Apache) Oozie CLI does not have WF 0.2 schema registered for validation
 OOZIE-22 (Apache) Add support PostgreSQL
 OOZIE-10 add user-retry in workflow action
 OOZIE-123 CoordKillXCommand command uniqueness and increase priority


### PR DESCRIPTION
Closes OOZIE-32 (Apache) Oozie CLI does not have WF 0.2 schema registered for validation
