### PR TITLE
[3.1] Closes OOZIE-35 add auto-rerun for error codes JA008 and JA009 in action executor

### DIFF
--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -1355,6 +1355,8 @@
     <property>
         <name>oozie.service.LiteWorkflowStoreService.user.retry.error.code</name>
         <value>
+            JA008,
+            JA009,
             JA017,
             JA018,
             FS009,
@@ -1365,6 +1367,8 @@
             FS009, FS008 is file exists error when using chmod in fs action.
             JA018 is output directory exists error in workflow map-reduce action.
             JA017 is job not exists error in action executor.
+            JA008 is FileNotFoundException in action executor.
+            JA009 is IOException in action executor.
         </description>
     </property>
     

--- a/docs/src/site/twiki/WorkflowFunctionalSpec.twiki
+++ b/docs/src/site/twiki/WorkflowFunctionalSpec.twiki
@@ -2282,7 +2282,8 @@ Oozie provides User-Retry capabilities when an action is in =ERROR= or =FAILED= 
 
 Depending on the nature of the failure, Oozie can define what type of errors allowed for User-Retry. There are certain errors
 Oozie is allowing for user-retry in default, for example, file-exists-error =FS009, FS008= when using chmod in workflow =fs=
-action, output-directory-exists-error =JA018= in workflow =map-reduce= action, and job-not-exists-error =JA017= in action executor. 
+action, output-directory-exists-error =JA018= in workflow =map-reduce= action, job-not-exists-error =JA017= in action executor,
+FileNotFoundException =JA008= in action executor, and IOException =JA009= in action executor.
 
 User-Retry allows user to give certain number of reties (must not exceed system max retries), so user can find the causes of
 that problem and fix them when action is in =USER_RETRY= state. If failure or error does not go away after max retries,

--- a/release-log.txt
+++ b/release-log.txt
@@ -1,5 +1,6 @@
 -- Oozie 3.1.0 release
 
+OOZIE-35 add auto-rerun for error codes JA008 and JA009 in action executor
 OOZIE-28 update coordinator name to coord job at loadstate of coord-submit to avoid exception of bundle-status-update 
 OOZIE-22 (Apache) Add support PostgreSQL
 OOZIE-10 add user-retry in workflow action


### PR DESCRIPTION
Closes OOZIE-35 add auto-rerun for error codes JA008 and JA009 in action executor
